### PR TITLE
[FIX] ssi_service_revenue_recognition

### DIFF
--- a/ssi_service_revenue_recognition/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition/models/service_contract_fix_item.py
@@ -21,8 +21,27 @@ class ServiceContractFixItem(models.Model):
     @api.depends(
         "service_id.analytic_account_id",
         "product_id",
+        "amount_untaxed",
     )
     def _compute_pob_id(self):
+        """Find the PoB already created for this line, if any.
+
+        ``service.contract_fix_item`` is a SQL view (see
+        ``ssi_service.models.service_contract_fix_item``) that groups the
+        underlying payment term detail rows by
+        ``product_id, product_category_id, name, price_unit, uom_id`` --
+        summing quantity/amounts across matching rows. Two lines that only
+        match by ``product_id`` (the previous search criteria here) can
+        still be *different* view rows when their ``price_unit`` differs,
+        so matching on product alone wrongly linked both to the first
+        line's PoB -- silently dropping the second line's amount from the
+        contract's total Performance Obligation. Including ``price_unit``
+        (via ``amount_untaxed``, which mirrors the view's per-line total
+        used when the PoB was created -- see ``_prepare_pob_data``) makes
+        the search key match the view's own grouping, so each distinct
+        view row gets its own PoB while rows the view already merged
+        (matching product/price) keep sharing one.
+        """
         for record in self:
             result = False
             if record.service_id.analytic_account_id and record.product_id:
@@ -34,6 +53,7 @@ class ServiceContractFixItem(models.Model):
                         record.service_id.analytic_account_id.id,
                     ),
                     ("product_id", "=", record.product_id.id),
+                    ("price_unit", "=", record.amount_untaxed),
                 ]
                 pobs = PoB.search(criteria)
                 if pobs:
@@ -51,6 +71,16 @@ class ServiceContractFixItem(models.Model):
         PoB = self.env["performance_obligation"]
         data = self._prepare_pob_data()
         PoB.create(data)
+        # pob_id is compute+store=False with a search() inside (see
+        # _compute_pob_id) rather than a real relational field path, so
+        # Odoo's @api.depends graph has no way to know that creating this
+        # new PoB should invalidate the pob_id already cached (as False)
+        # for this record from the `if self.pob_id:` check above -- it
+        # would otherwise keep reading stale from cache for the rest of
+        # this transaction. Force a fresh compute so callers that keep
+        # using this record/transaction (scripts, tests, other lines
+        # processed by the same action_create_pob call) see it right away.
+        self.invalidate_cache(fnames=["pob_id"], ids=self.ids)
 
     def _prepare_pob_data(self):
         self.ensure_one()

--- a/ssi_service_revenue_recognition/tests/__init__.py
+++ b/ssi_service_revenue_recognition/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_service_contract_fix_item_pob

--- a/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
+++ b/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
@@ -1,0 +1,215 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestServiceContractFixItemPob(TransactionCase):
+    """Covers ``service.contract_fix_item.action_create_pob``.
+
+    ``service.contract_fix_item`` is a SQL view (see
+    ``ssi_service.models.service_contract_fix_item``) that groups the
+    underlying payment term detail rows by
+    ``product_id, product_category_id, name, price_unit, uom_id``. Two
+    detail lines for the *same* product but *different* price therefore
+    surface as two distinct view rows -- but ``_compute_pob_id`` used to
+    search for an existing Performance Obligation by ``product_id`` alone,
+    so the second row silently linked to the first row's PoB instead of
+    getting its own, understating the contract's total Performance
+    Obligation by the second row's amount.
+
+    Reported in ticket OFS/26/000023 -- reproduced against real data on
+    contract SVC/2026/000001 (two "Jasa Renovasi Ruangan" lines, Rp
+    20.975.000 and Rp 398.525.000, both wrongly linked to the same PoB).
+    """
+
+    def setUp(self):
+        super().setUp()
+        env = self.env
+        admin = env.ref("base.user_admin")
+        self.admin = admin
+
+        self.income_account = env["account.account"].search(
+            [("user_type_id.internal_group", "=", "income")], limit=1
+        )
+        self.uom = env.ref("uom.product_uom_unit")
+
+        self.partner = (
+            env["res.partner"]
+            .with_user(admin)
+            .create({"name": "Test Partner - PoB", "is_company": True})
+        )
+        self.pricelist = env.ref("product.list0")
+        self.service_type = (
+            env["service.type"]
+            .with_user(admin)
+            .create({"name": "Test Service Type - PoB", "code": "POBT"})
+        )
+        self.product = (
+            env["product.product"]
+            .with_user(admin)
+            .create(
+                {
+                    "name": "Test Generic Lumpsum Service - PoB",
+                    "type": "service",
+                    "uom_id": self.uom.id,
+                    "uom_po_id": self.uom.id,
+                }
+            )
+        )
+        self.contract = (
+            env["service.contract"]
+            .with_user(admin)
+            .create(
+                {
+                    "title": "Test Service Contract - PoB",
+                    "partner_id": self.partner.id,
+                    "type_id": self.service_type.id,
+                    "manager_id": admin.id,
+                    "salesperson_id": admin.id,
+                    "pricelist_id": self.pricelist.id,
+                    "currency_id": env.ref("base.USD").id,
+                    "date": "2026-01-01",
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-12-31",
+                }
+            )
+        )
+        self.contract.with_user(admin).action_confirm()
+        self.contract.with_user(admin).with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        self.contract.invalidate_cache()
+        assert self.contract.state == "open"
+        assert self.contract.analytic_account_id
+
+    def _create_payment_term(self, name, price_unit):
+        term = (
+            self.env["service.contract_fix_item_payment_term"]
+            .with_user(self.admin)
+            .create(
+                {
+                    "service_id": self.contract.id,
+                    "name": name,
+                    "sequence": 10,
+                }
+            )
+        )
+        detail = (
+            self.env["service.contract_fix_item_payment_term_detail"]
+            .with_user(self.admin)
+            .create(
+                {
+                    "term_id": term.id,
+                    "product_id": self.product.id,
+                    "name": self.product.name,
+                    "account_id": self.income_account.id,
+                    "price_unit": price_unit,
+                    "quantity": 1,
+                    "uom_quantity": 1,
+                    "uom_id": self.uom.id,
+                    "sequence": 10,
+                }
+            )
+        )
+        # service.contract_fix_item is a SQL view reading straight from this
+        # model's real table (see _get_fix_items below) -- price_subtotal
+        # (which the view sums into amount_untaxed) is a stored compute
+        # field, and querying the view does not by itself flush *this*
+        # model's pending compute writes. Without an explicit flush here,
+        # the view sees amount_untaxed as still 0 for a freshly created
+        # line.
+        detail.flush()
+        return term
+
+    def _get_fix_items(self):
+        """Fetch every ``service.contract_fix_item`` view row for the test
+        contract/product in a single query.
+
+        The underlying view assigns ids via ``ROW_NUMBER() OVER()`` with no
+        ``ORDER BY`` (see ``ssi_service.models.service_contract_fix_item``),
+        so id numbering is only self-consistent *within one query
+        execution* -- fetching each row via a separate, more narrowly
+        filtered ``search()`` call (e.g. one call per ``price_unit``) can
+        have Postgres assign the *same* id to two different rows across
+        those separate executions, making Odoo treat them as one record.
+        Always fetch the full set once and split it with ``.filtered()``
+        in Python instead.
+        """
+        return self.env["service.contract_fix_item"].search(
+            [
+                ("service_id", "=", self.contract.id),
+                ("product_id", "=", self.product.id),
+            ]
+        )
+
+    def test_different_price_lines_get_distinct_pob(self):
+        """Same product, different price -> action_create_pob must not
+        silently merge the second line's PoB into the first line's."""
+        self._create_payment_term("Term 1", 20975000)
+        self._create_payment_term("Term 2", 398525000)
+
+        all_items = self._get_fix_items()
+        self.assertEqual(len(all_items), 2)
+        item_low = all_items.filtered(lambda i: i.price_unit == 20975000)
+        item_high = all_items.filtered(lambda i: i.price_unit == 398525000)
+        self.assertTrue(item_low)
+        self.assertTrue(item_high)
+        self.assertFalse(item_low.pob_id)
+        self.assertFalse(item_high.pob_id)
+
+        all_items.action_create_pob()
+
+        all_items = self._get_fix_items()
+        item_low = all_items.filtered(lambda i: i.price_unit == 20975000)
+        item_high = all_items.filtered(lambda i: i.price_unit == 398525000)
+        self.assertTrue(item_low.pob_id)
+        self.assertTrue(item_high.pob_id)
+        self.assertNotEqual(
+            item_low.pob_id.id,
+            item_high.pob_id.id,
+            "lines with different price must not share the same PoB",
+        )
+        self.assertEqual(item_low.pob_id.price_unit, 20975000)
+        self.assertEqual(item_high.pob_id.price_unit, 398525000)
+
+    def test_same_price_lines_share_one_pob(self):
+        """Same product, same price across two terms -> the underlying SQL
+        view already groups/sums them into a single row (quantity and
+        amount summed across the matching lines), so there is only ever
+        one PoB to create for it (sanity check of the view's own
+        grouping, not just the compute fix)."""
+        self._create_payment_term("Term 1", 15000000)
+        self._create_payment_term("Term 2", 15000000)
+
+        item = self._get_fix_items()
+        self.assertEqual(len(item), 1)
+        self.assertEqual(item.quantity, 2)
+        self.assertEqual(item.amount_untaxed, 30000000)
+
+        item.action_create_pob()
+
+        item = self._get_fix_items()
+        self.assertTrue(item.pob_id)
+        self.assertEqual(item.pob_id.uom_quantity, 2)
+        self.assertEqual(item.pob_id.price_unit, 30000000)
+
+        item.action_create_pob()
+        self.assertEqual(
+            self.env["performance_obligation"].search_count(
+                [
+                    (
+                        "source_analytic_account_id",
+                        "=",
+                        self.contract.analytic_account_id.id,
+                    ),
+                    ("product_id", "=", self.product.id),
+                    ("price_unit", "=", 30000000),
+                ]
+            ),
+            1,
+            "calling action_create_pob again must not create a duplicate PoB",
+        )


### PR DESCRIPTION
service.contract_fix_item._compute_pob_id() sekarang ikut mencocokkan price_unit, sesuai GROUP BY di SQL view service.contract_fix_item. Sebelumnya baris dengan produk sama tapi harga berbeda diam-diam berbagi PoB yang sama, membuat nilai PoB baris kedua hilang dari total kontrak.

Tambah unit test. Diverifikasi terhadap data produksi-lokal SGRS (kontrak SVC/2026/000001).

Dilaporkan di ticket OFS/26/000023.