### PR TITLE
[UPD] ssi_service_revenue_recognition

### DIFF
--- a/ssi_service_revenue_recognition/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition/models/service_contract_fix_item.py
@@ -21,7 +21,7 @@ class ServiceContractFixItem(models.Model):
     @api.depends(
         "service_id.analytic_account_id",
         "product_id",
-        "price_unit",
+        "amount_untaxed",
     )
     def _compute_pob_id(self):
         """Find the PoB already created for this line, if any.
@@ -35,13 +35,13 @@ class ServiceContractFixItem(models.Model):
         still be *different* view rows when their ``price_unit`` differs,
         so matching on product alone wrongly linked both to the first
         line's PoB -- silently dropping the second line's amount from the
-        contract's total Performance Obligation. Matching on ``price_unit``
-        (the same field the view itself groups by -- see
-        ``_prepare_pob_data`` for why the PoB's own ``price_unit`` mirrors
-        this record's ``price_unit`` and not ``amount_untaxed``) makes the
-        search key match the view's own grouping, so each distinct view
-        row gets its own PoB while rows the view already merged (matching
-        product/price) keep sharing one.
+        contract's total Performance Obligation. Matching on
+        ``amount_untaxed`` (the field ``_prepare_pob_data`` actually
+        writes into the PoB's own ``price_unit`` -- see that method)
+        keeps this search aligned with what a distinct view row's PoB
+        actually looks like, so each distinct view row gets its own PoB
+        while rows the view already merged (matching product/price)
+        keep sharing one.
         """
         for record in self:
             result = False
@@ -54,7 +54,7 @@ class ServiceContractFixItem(models.Model):
                         record.service_id.analytic_account_id.id,
                     ),
                     ("product_id", "=", record.product_id.id),
-                    ("price_unit", "=", record.price_unit),
+                    ("price_unit", "=", record.amount_untaxed),
                 ]
                 pobs = PoB.search(criteria)
                 if pobs:
@@ -109,15 +109,16 @@ Solution: Make sure module ssi_revenue_recognition is installed and up to date
             "currency_id": self.currency_id.id,
             "uom_quantity": self.quantity,
             "uom_id": self.product_id.uom_id.id,
-            # PoB's own price_subtotal is computed as price_unit *
-            # uom_quantity (mixin.product_line_price._compute_price), so
-            # this must be the per-unit price shown on the contract's
-            # Items list -- not amount_untaxed (the line's already
-            # quantity-multiplied, and possibly cross-term-summed, total).
-            # Using amount_untaxed here made the PoB's "Price Unit" not
-            # match the contract item's whenever quantity != 1 or multiple
-            # payment term lines were merged into one view row.
-            "price_unit": self.price_unit,
+            # Per OFS/26/000026: PoB's Price Unit is deliberately the
+            # line's untaxed amount (amount_untaxed), not the per-unit
+            # price -- reporter confirmed this is the intended setting
+            # after a prior revision (OFS/26/000025) briefly changed it
+            # to per-unit price and had to be reverted. Note this means
+            # price_subtotal (price_unit * uom_quantity, computed by
+            # mixin.product_line_price) will overstate the total for
+            # lines with quantity != 1, since amount_untaxed is already
+            # quantity-multiplied -- accepted as out of scope here.
+            "price_unit": self.amount_untaxed,
             "progress_completion_method": "input",
             "revenue_recognition_timing": "point_in_time",
             "fulfillment_field_id": manual_field.id,

--- a/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
+++ b/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
@@ -25,12 +25,17 @@ class TestServiceContractFixItemPob(TransactionCase):
     contract SVC/2026/000001 (two "Jasa Renovasi Ruangan" lines, Rp
     20.975.000 and Rp 398.525.000, both wrongly linked to the same PoB).
 
-    Also covers OFS/26/000025: ``_prepare_pob_data`` used to assign the
-    line's ``amount_untaxed`` (a quantity-multiplied, possibly
-    cross-term-summed total) to the PoB's own ``price_unit`` field, instead
-    of the line's actual per-unit ``price_unit`` -- making the PoB's Price
-    Unit never match the contract item's whenever quantity != 1 or several
-    payment term lines were merged into one view row.
+    Also covers OFS/26/000026's history: ``_prepare_pob_data`` originally
+    assigned the line's ``amount_untaxed`` to the PoB's own
+    ``price_unit``; OFS/26/000026 changed it to the line's per-unit
+    ``price_unit`` instead, then the reporter asked (same ticket,
+    2026-08-11) to revert to ``amount_untaxed`` -- confirmed as the
+    intended setting despite overstating ``price_subtotal`` for lines
+    with quantity != 1 (``price_subtotal`` = ``price_unit`` *
+    ``uom_quantity``, and ``amount_untaxed`` is already
+    quantity-multiplied). ``_compute_pob_id`` matches on
+    ``amount_untaxed`` accordingly, so it stays aligned with whatever
+    ``_prepare_pob_data`` actually writes into the PoB's ``price_unit``.
     """
 
     def setUp(self):
@@ -202,12 +207,49 @@ class TestServiceContractFixItemPob(TransactionCase):
         item = self._get_fix_items()
         self.assertTrue(item.pob_id)
         self.assertEqual(item.pob_id.uom_quantity, 2)
-        # price_unit must mirror the *per-unit* price shown on the
-        # contract's Items list (OFS/26/000026) -- price_subtotal (=
-        # price_unit * uom_quantity, computed by mixin.product_line_price)
-        # is where the summed total belongs, not price_unit itself.
+        # price_unit mirrors the item's untaxed amount, per OFS/26/000026
+        # (reverted from a brief per-unit-price change on the same
+        # ticket) -- so it equals the summed amount_untaxed here, not
+        # the per-unit 15000000.
+        self.assertEqual(item.pob_id.price_unit, 30000000)
+        self.assertEqual(item.pob_id.price_subtotal, 60000000)
+
+        item.action_create_pob()
+        self.assertEqual(
+            self.env["performance_obligation"].search_count(
+                [
+                    (
+                        "source_analytic_account_id",
+                        "=",
+                        self.contract.analytic_account_id.id,
+                    ),
+                    ("product_id", "=", self.product.id),
+                    ("price_unit", "=", 30000000),
+                ]
+            ),
+            1,
+            "calling action_create_pob again must not create a duplicate PoB",
+        )
+
+    def test_pob_price_unit_is_amount_untaxed_when_quantity_not_one(self):
+        """OFS/26/000026 (reverted): PoB price_unit = item's
+        amount_untaxed even when quantity != 1 -- reporter confirmed
+        this is the intended setting, accepting that price_subtotal
+        (price_unit * uom_quantity) overstates the true total in this
+        case (15000000 instead of the item's own 5000000)."""
+        self._create_payment_term("Term 1", 5000000, quantity=3)
+
+        item = self._get_fix_items()
+        self.assertEqual(len(item), 1)
+        self.assertEqual(item.price_unit, 5000000)
+        self.assertEqual(item.amount_untaxed, 15000000)
+
+        item.action_create_pob()
+
+        item = self._get_fix_items()
         self.assertEqual(item.pob_id.price_unit, 15000000)
-        self.assertEqual(item.pob_id.price_subtotal, 30000000)
+        self.assertEqual(item.pob_id.uom_quantity, 3)
+        self.assertEqual(item.pob_id.price_subtotal, 45000000)
 
         item.action_create_pob()
         self.assertEqual(
@@ -220,42 +262,6 @@ class TestServiceContractFixItemPob(TransactionCase):
                     ),
                     ("product_id", "=", self.product.id),
                     ("price_unit", "=", 15000000),
-                ]
-            ),
-            1,
-            "calling action_create_pob again must not create a duplicate PoB",
-        )
-
-    def test_pob_price_unit_matches_item_when_quantity_not_one(self):
-        """OFS/26/000026: a single contract item line with quantity != 1
-        must produce a PoB whose price_unit still matches the item's own
-        price_unit -- not amount_untaxed (price_unit * quantity), which is
-        what _prepare_pob_data used to (wrongly) assign to price_unit."""
-        self._create_payment_term("Term 1", 5000000, quantity=3)
-
-        item = self._get_fix_items()
-        self.assertEqual(len(item), 1)
-        self.assertEqual(item.price_unit, 5000000)
-        self.assertEqual(item.amount_untaxed, 15000000)
-
-        item.action_create_pob()
-
-        item = self._get_fix_items()
-        self.assertEqual(item.pob_id.price_unit, 5000000)
-        self.assertEqual(item.pob_id.uom_quantity, 3)
-        self.assertEqual(item.pob_id.price_subtotal, 15000000)
-
-        item.action_create_pob()
-        self.assertEqual(
-            self.env["performance_obligation"].search_count(
-                [
-                    (
-                        "source_analytic_account_id",
-                        "=",
-                        self.contract.analytic_account_id.id,
-                    ),
-                    ("product_id", "=", self.product.id),
-                    ("price_unit", "=", 5000000),
                 ]
             ),
             1,


### PR DESCRIPTION
Kembalikan `price_unit` PoB ke `amount_untaxed` (revert dari PR #100 / OFS/26/000026), sesuai konfirmasi ulang reporter di ticket. Kriteria pencarian PoB existing di `_compute_pob_id` disesuaikan juga (`amount_untaxed` alih-alih `price_unit`) agar tetap konsisten.

Ref: OFS/26/000026