### PR TITLE
[FIX] ssi_service_revenue_recognition

### DIFF
--- a/ssi_service_revenue_recognition/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition/models/service_contract_fix_item.py
@@ -22,6 +22,7 @@ class ServiceContractFixItem(models.Model):
         "service_id.analytic_account_id",
         "product_id",
         "amount_untaxed",
+        "quantity",
     )
     def _compute_pob_id(self):
         """Find the PoB already created for this line, if any.
@@ -35,13 +36,13 @@ class ServiceContractFixItem(models.Model):
         still be *different* view rows when their ``price_unit`` differs,
         so matching on product alone wrongly linked both to the first
         line's PoB -- silently dropping the second line's amount from the
-        contract's total Performance Obligation. Matching on
-        ``amount_untaxed`` (the field ``_prepare_pob_data`` actually
-        writes into the PoB's own ``price_unit`` -- see that method)
-        keeps this search aligned with what a distinct view row's PoB
-        actually looks like, so each distinct view row gets its own PoB
-        while rows the view already merged (matching product/price)
-        keep sharing one.
+        contract's total Performance Obligation. Matching on the same
+        per-unit untaxed price ``_prepare_pob_data`` writes into the
+        PoB's own ``price_unit`` (see ``_get_pob_price_unit`` and that
+        method) keeps this search aligned with what a distinct view
+        row's PoB actually looks like, so each distinct view row gets
+        its own PoB while rows the view already merged (matching
+        product/price) keep sharing one.
         """
         for record in self:
             result = False
@@ -54,12 +55,35 @@ class ServiceContractFixItem(models.Model):
                         record.service_id.analytic_account_id.id,
                     ),
                     ("product_id", "=", record.product_id.id),
-                    ("price_unit", "=", record.amount_untaxed),
+                    ("price_unit", "=", record._get_pob_price_unit()),
                 ]
                 pobs = PoB.search(criteria)
                 if pobs:
                     result = pobs[0]
             record.pob_id = result
+
+    def _get_pob_price_unit(self):
+        """Compute the per-unit untaxed price to store on the PoB.
+
+        The view's ``amount_untaxed`` is the line's *total* untaxed
+        amount (already multiplied by ``quantity``, and possibly summed
+        across several payment term lines the view merged -- see
+        ``ssi_service.models.service_contract_fix_item``), while the
+        PoB's own ``price_subtotal`` is computed as
+        ``price_unit * uom_quantity`` (``mixin.product_line_price``).
+        Dividing by ``quantity`` here is what keeps that product equal
+        to ``amount_untaxed`` again for lines with quantity != 1,
+        instead of overstating it (OFS/26/000026). This must not be the
+        item's own ``price_unit`` field either -- that is the contract's
+        *tax-inclusive* per-unit price, and the reporter confirmed the
+        PoB unit price must be untaxed (OFS/26/000025).
+
+        :return: per-unit untaxed price, or ``0.0`` if quantity is zero
+        """
+        self.ensure_one()
+        if not self.quantity:
+            return 0.0
+        return self.amount_untaxed / self.quantity
 
     def action_create_pob(self):
         for record in self.sudo():
@@ -109,16 +133,10 @@ Solution: Make sure module ssi_revenue_recognition is installed and up to date
             "currency_id": self.currency_id.id,
             "uom_quantity": self.quantity,
             "uom_id": self.product_id.uom_id.id,
-            # Per OFS/26/000026: PoB's Price Unit is deliberately the
-            # line's untaxed amount (amount_untaxed), not the per-unit
-            # price -- reporter confirmed this is the intended setting
-            # after a prior revision (OFS/26/000025) briefly changed it
-            # to per-unit price and had to be reverted. Note this means
-            # price_subtotal (price_unit * uom_quantity, computed by
-            # mixin.product_line_price) will overstate the total for
-            # lines with quantity != 1, since amount_untaxed is already
-            # quantity-multiplied -- accepted as out of scope here.
-            "price_unit": self.amount_untaxed,
+            # See _get_pob_price_unit: per-unit untaxed price, so
+            # price_subtotal (price_unit * uom_quantity) matches
+            # amount_untaxed again even when quantity != 1.
+            "price_unit": self._get_pob_price_unit(),
             "progress_completion_method": "input",
             "revenue_recognition_timing": "point_in_time",
             "fulfillment_field_id": manual_field.id,

--- a/ssi_service_revenue_recognition/tests/test_data_service_contract_fix_item_pob.yaml
+++ b/ssi_service_revenue_recognition/tests/test_data_service_contract_fix_item_pob.yaml
@@ -191,7 +191,9 @@ scenarios:
         refresh: true
         expect_count: 1
 
-      - step: "Assert PoB price_unit is per-unit untaxed, price_subtotal matches amount_untaxed"
+      - step:
+          "Assert PoB price_unit is per-unit untaxed, price_subtotal matches
+          amount_untaxed"
         action: "assert"
         target: "pob"
         asserts:

--- a/ssi_service_revenue_recognition/tests/test_data_service_contract_fix_item_pob.yaml
+++ b/ssi_service_revenue_recognition/tests/test_data_service_contract_fix_item_pob.yaml
@@ -1,0 +1,447 @@
+scenarios:
+  - name: "PoB price_unit is the per-unit untaxed price (OFS/26/000026)"
+    steps:
+      - step: "Get income account"
+        action: "search"
+        model: "account.account"
+        domain: [["user_type_id.internal_group", "=", "income"]]
+        save_as: "income_account"
+        limit: 1
+
+      - step: "Get generic unit of measure"
+        action: "ref"
+        xml_id: "uom.product_uom_unit"
+        save_as: "uom"
+
+      - step: "Get default pricelist"
+        action: "ref"
+        xml_id: "product.list0"
+        save_as: "pricelist"
+
+      - step: "Create 25% price-included sale tax"
+        action: "create"
+        model: "account.tax"
+        save_as: "tax25"
+        as_user: "base.user_admin"
+        values:
+          name: "Test PPN 25% Incl - PoB price_unit"
+          amount: 25.0
+          amount_type: "percent"
+          type_tax_use: "sale"
+          price_include: true
+          company_id: "REC: company.id"
+
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB price_unit"
+          is_company: true
+
+      - step: "Create test service type"
+        action: "create"
+        model: "service.type"
+        save_as: "service_type"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Service Type - PoB price_unit"
+          code: "POBPU1"
+
+      - step: "Create test product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lumpsum Service - PoB price_unit"
+          type: "service"
+          uom_id: "REC: uom.id"
+          uom_po_id: "REC: uom.id"
+
+      - step: "Create service contract"
+        action: "create"
+        model: "service.contract"
+        save_as: "contract"
+        as_user: "base.user_admin"
+        values:
+          title: "Test Service Contract - PoB price_unit"
+          partner_id: "REC: partner.id"
+          type_id: "REC: service_type.id"
+          manager_id: "REF: base.user_admin"
+          salesperson_id: "REF: base.user_admin"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          date: "2026-01-01"
+          date_start: "2026-01-01"
+          date_end: "2026-12-31"
+
+      - step: "Confirm contract"
+        action: "call"
+        target: "contract"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Assert confirmed (forces refresh before approve reads policy)"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve contract (opens it, auto-creates analytic account)"
+        action: "call"
+        target: "contract"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Assert contract open with its own analytic account"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "service.contract_fix_item_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          service_id: "REC: contract.id"
+          name: "Term 1"
+          sequence: 10
+
+      - step: "Create payment term detail (qty 4, tax-inclusive unit price 500)"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 500
+          quantity: 4
+          uom_quantity: 4
+          uom_id: "REC: uom.id"
+          tax_ids:
+            - - 6
+              - 0
+              - - "REC: tax25.id"
+          sequence: 10
+
+      - step: "Fetch the contract fix item view row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "item"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert item's own untaxed total (500 tax-incl x 4 / 1.25)"
+        action: "assert"
+        target: "item"
+        asserts:
+          quantity:
+            type: "value"
+            expected: 4.0
+          price_unit:
+            type: "value"
+            expected: 500.0
+          amount_untaxed:
+            type: "value"
+            expected: 1600.0
+
+      - step: "Create the PoB from the item"
+        action: "call"
+        target: "item"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Assert item now links to a PoB"
+        action: "assert"
+        target: "item"
+        refresh: true
+        asserts:
+          pob_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Fetch the created PoB"
+        action: "search"
+        model: "performance_obligation"
+        domain:
+          - ["source_analytic_account_id", "=", "REC: contract.analytic_account_id.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "pob"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert PoB price_unit is per-unit untaxed, price_subtotal matches amount_untaxed"
+        action: "assert"
+        target: "pob"
+        asserts:
+          uom_quantity:
+            type: "value"
+            expected: 4.0
+          price_unit:
+            # 400 = amount_untaxed (1600) / quantity (4) -- not the raw
+            # contract item's own (tax-inclusive) price_unit of 500.
+            type: "value"
+            expected: 400.0
+          price_subtotal:
+            type: "value"
+            expected: "REC: item.amount_untaxed"
+
+  - name: "Distinct-price lines get distinct PoBs; action_create_pob is idempotent"
+    steps:
+      - step: "Get income account"
+        action: "search"
+        model: "account.account"
+        domain: [["user_type_id.internal_group", "=", "income"]]
+        save_as: "income_account"
+        limit: 1
+
+      - step: "Get generic unit of measure"
+        action: "ref"
+        xml_id: "uom.product_uom_unit"
+        save_as: "uom"
+
+      - step: "Get default pricelist"
+        action: "ref"
+        xml_id: "product.list0"
+        save_as: "pricelist"
+
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB distinct price"
+          is_company: true
+
+      - step: "Create test service type"
+        action: "create"
+        model: "service.type"
+        save_as: "service_type"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Service Type - PoB distinct price"
+          code: "POBPU2"
+
+      - step: "Create test product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lumpsum Service - PoB distinct price"
+          type: "service"
+          uom_id: "REC: uom.id"
+          uom_po_id: "REC: uom.id"
+
+      - step: "Create service contract"
+        action: "create"
+        model: "service.contract"
+        save_as: "contract"
+        as_user: "base.user_admin"
+        values:
+          title: "Test Service Contract - PoB distinct price"
+          partner_id: "REC: partner.id"
+          type_id: "REC: service_type.id"
+          manager_id: "REF: base.user_admin"
+          salesperson_id: "REF: base.user_admin"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          date: "2026-01-01"
+          date_start: "2026-01-01"
+          date_end: "2026-12-31"
+
+      - step: "Confirm contract"
+        action: "call"
+        target: "contract"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Assert confirmed (forces refresh before approve reads policy)"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve contract"
+        action: "call"
+        target: "contract"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Assert contract open"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "service.contract_fix_item_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          service_id: "REC: contract.id"
+          name: "Term 1"
+          sequence: 10
+
+      - step: "Create low-price detail line"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail_low"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 200000
+          quantity: 1
+          uom_quantity: 1
+          uom_id: "REC: uom.id"
+          sequence: 10
+
+      - step: "Create high-price detail line"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail_high"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 500000
+          quantity: 1
+          uom_quantity: 1
+          uom_id: "REC: uom.id"
+          sequence: 20
+
+      - step: "Fetch the low-price item row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+          - ["price_unit", "=", 200000]
+        save_as: "item_low"
+        refresh: true
+        expect_count: 1
+
+      - step: "Fetch the high-price item row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+          - ["price_unit", "=", 500000]
+        save_as: "item_high"
+        expect_count: 1
+
+      - step: "Neither item has a PoB yet"
+        action: "assert"
+        target: "item_low"
+        asserts:
+          pob_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Create PoB for the low-price item"
+        action: "call"
+        target: "item_low"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Create PoB for the high-price item"
+        action: "call"
+        target: "item_high"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Re-fetch both items with fresh pob_id"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+          - ["price_unit", "=", 200000]
+        save_as: "item_low"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert low-price item's PoB"
+        action: "assert"
+        target: "item_low"
+        asserts:
+          pob_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Re-fetch high-price item with fresh pob_id"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+          - ["price_unit", "=", 500000]
+        save_as: "item_high"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert high-price item's PoB differs from the low-price one's"
+        action: "assert"
+        target: "item_high"
+        asserts:
+          pob_id:
+            type: "value"
+            operator: "is_truthy"
+          pob_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REC: item_low.pob_id.id"
+
+      - step: "Calling action_create_pob again must not duplicate the PoB"
+        action: "call"
+        target: "item_low"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Assert only one PoB exists for the low price"
+        action: "search"
+        model: "performance_obligation"
+        domain:
+          - ["source_analytic_account_id", "=", "REC: contract.analytic_account_id.id"]
+          - ["product_id", "=", "REC: product.id"]
+          - ["price_unit", "=", 200000]
+        save_as: "pob_low_all"
+        refresh: true
+        expect_count: 1

--- a/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
+++ b/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
@@ -2,9 +2,9 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import tagged
-
 from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")

--- a/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
+++ b/ssi_service_revenue_recognition/tests/test_service_contract_fix_item_pob.py
@@ -3,11 +3,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+
+from odoo_yaml_test import YamlTransactionCase
 
 
 @tagged("post_install", "-at_install")
-class TestServiceContractFixItemPob(TransactionCase):
+class TestServiceContractFixItemPob(YamlTransactionCase):
     """Covers ``service.contract_fix_item.action_create_pob``.
 
     ``service.contract_fix_item`` is a SQL view (see
@@ -19,251 +20,25 @@ class TestServiceContractFixItemPob(TransactionCase):
     search for an existing Performance Obligation by ``product_id`` alone,
     so the second row silently linked to the first row's PoB instead of
     getting its own, understating the contract's total Performance
-    Obligation by the second row's amount.
+    Obligation by the second row's amount (OFS/26/000023).
 
-    Reported in ticket OFS/26/000023 -- reproduced against real data on
-    contract SVC/2026/000001 (two "Jasa Renovasi Ruangan" lines, Rp
-    20.975.000 and Rp 398.525.000, both wrongly linked to the same PoB).
-
-    Also covers OFS/26/000026's history: ``_prepare_pob_data`` originally
-    assigned the line's ``amount_untaxed`` to the PoB's own
-    ``price_unit``; OFS/26/000026 changed it to the line's per-unit
-    ``price_unit`` instead, then the reporter asked (same ticket,
-    2026-08-11) to revert to ``amount_untaxed`` -- confirmed as the
-    intended setting despite overstating ``price_subtotal`` for lines
-    with quantity != 1 (``price_subtotal`` = ``price_unit`` *
-    ``uom_quantity``, and ``amount_untaxed`` is already
-    quantity-multiplied). ``_compute_pob_id`` matches on
-    ``amount_untaxed`` accordingly, so it stays aligned with whatever
-    ``_prepare_pob_data`` actually writes into the PoB's ``price_unit``.
+    Also covers OFS/26/000026's full history: ``_prepare_pob_data``
+    originally assigned the line's ``amount_untaxed`` (already
+    quantity-multiplied) to the PoB's own ``price_unit``, which was
+    changed to the line's own (tax-inclusive) ``price_unit`` field, then
+    reverted back to ``amount_untaxed`` on the same ticket -- accepting
+    that ``price_subtotal`` (``price_unit * uom_quantity``) would
+    overstate the total for lines with quantity != 1. Real usage on
+    contract SVC/2026/000001 (a quantity=2 line) then hit exactly that
+    overstatement, so the ticket was reopened: the PoB's ``price_unit``
+    must be the line's **per-unit untaxed** price -- neither the raw
+    (tax-inclusive) contract ``price_unit`` nor the line's full
+    (quantity-multiplied) ``amount_untaxed`` -- so that
+    ``price_subtotal`` matches ``amount_untaxed`` again regardless of
+    quantity. See ``_get_pob_price_unit`` in
+    ``service_contract_fix_item.py``.
     """
 
-    def setUp(self):
-        super().setUp()
-        env = self.env
-        admin = env.ref("base.user_admin")
-        self.admin = admin
-
-        self.income_account = env["account.account"].search(
-            [("user_type_id.internal_group", "=", "income")], limit=1
-        )
-        self.uom = env.ref("uom.product_uom_unit")
-
-        self.partner = (
-            env["res.partner"]
-            .with_user(admin)
-            .create({"name": "Test Partner - PoB", "is_company": True})
-        )
-        self.pricelist = env.ref("product.list0")
-        self.service_type = (
-            env["service.type"]
-            .with_user(admin)
-            .create({"name": "Test Service Type - PoB", "code": "POBT"})
-        )
-        self.product = (
-            env["product.product"]
-            .with_user(admin)
-            .create(
-                {
-                    "name": "Test Generic Lumpsum Service - PoB",
-                    "type": "service",
-                    "uom_id": self.uom.id,
-                    "uom_po_id": self.uom.id,
-                }
-            )
-        )
-        self.contract = (
-            env["service.contract"]
-            .with_user(admin)
-            .create(
-                {
-                    "title": "Test Service Contract - PoB",
-                    "partner_id": self.partner.id,
-                    "type_id": self.service_type.id,
-                    "manager_id": admin.id,
-                    "salesperson_id": admin.id,
-                    "pricelist_id": self.pricelist.id,
-                    "currency_id": env.ref("base.USD").id,
-                    "date": "2026-01-01",
-                    "date_start": "2026-01-01",
-                    "date_end": "2026-12-31",
-                }
-            )
-        )
-        self.contract.with_user(admin).action_confirm()
-        self.contract.with_user(admin).with_context(
-            bypass_policy_check=True
-        ).action_approve_approval()
-        self.contract.invalidate_cache()
-        assert self.contract.state == "open"
-        assert self.contract.analytic_account_id
-
-    def _create_payment_term(self, name, price_unit, quantity=1):
-        term = (
-            self.env["service.contract_fix_item_payment_term"]
-            .with_user(self.admin)
-            .create(
-                {
-                    "service_id": self.contract.id,
-                    "name": name,
-                    "sequence": 10,
-                }
-            )
-        )
-        detail = (
-            self.env["service.contract_fix_item_payment_term_detail"]
-            .with_user(self.admin)
-            .create(
-                {
-                    "term_id": term.id,
-                    "product_id": self.product.id,
-                    "name": self.product.name,
-                    "account_id": self.income_account.id,
-                    "price_unit": price_unit,
-                    "quantity": quantity,
-                    "uom_quantity": quantity,
-                    "uom_id": self.uom.id,
-                    "sequence": 10,
-                }
-            )
-        )
-        # service.contract_fix_item is a SQL view reading straight from this
-        # model's real table (see _get_fix_items below) -- price_subtotal
-        # (which the view sums into amount_untaxed) is a stored compute
-        # field, and querying the view does not by itself flush *this*
-        # model's pending compute writes. Without an explicit flush here,
-        # the view sees amount_untaxed as still 0 for a freshly created
-        # line.
-        detail.flush()
-        return term
-
-    def _get_fix_items(self):
-        """Fetch every ``service.contract_fix_item`` view row for the test
-        contract/product in a single query.
-
-        The underlying view assigns ids via ``ROW_NUMBER() OVER()`` with no
-        ``ORDER BY`` (see ``ssi_service.models.service_contract_fix_item``),
-        so id numbering is only self-consistent *within one query
-        execution* -- fetching each row via a separate, more narrowly
-        filtered ``search()`` call (e.g. one call per ``price_unit``) can
-        have Postgres assign the *same* id to two different rows across
-        those separate executions, making Odoo treat them as one record.
-        Always fetch the full set once and split it with ``.filtered()``
-        in Python instead.
-        """
-        return self.env["service.contract_fix_item"].search(
-            [
-                ("service_id", "=", self.contract.id),
-                ("product_id", "=", self.product.id),
-            ]
-        )
-
-    def test_different_price_lines_get_distinct_pob(self):
-        """Same product, different price -> action_create_pob must not
-        silently merge the second line's PoB into the first line's."""
-        self._create_payment_term("Term 1", 20975000)
-        self._create_payment_term("Term 2", 398525000)
-
-        all_items = self._get_fix_items()
-        self.assertEqual(len(all_items), 2)
-        item_low = all_items.filtered(lambda i: i.price_unit == 20975000)
-        item_high = all_items.filtered(lambda i: i.price_unit == 398525000)
-        self.assertTrue(item_low)
-        self.assertTrue(item_high)
-        self.assertFalse(item_low.pob_id)
-        self.assertFalse(item_high.pob_id)
-
-        all_items.action_create_pob()
-
-        all_items = self._get_fix_items()
-        item_low = all_items.filtered(lambda i: i.price_unit == 20975000)
-        item_high = all_items.filtered(lambda i: i.price_unit == 398525000)
-        self.assertTrue(item_low.pob_id)
-        self.assertTrue(item_high.pob_id)
-        self.assertNotEqual(
-            item_low.pob_id.id,
-            item_high.pob_id.id,
-            "lines with different price must not share the same PoB",
-        )
-        self.assertEqual(item_low.pob_id.price_unit, 20975000)
-        self.assertEqual(item_high.pob_id.price_unit, 398525000)
-
-    def test_same_price_lines_share_one_pob(self):
-        """Same product, same price across two terms -> the underlying SQL
-        view already groups/sums them into a single row (quantity and
-        amount summed across the matching lines), so there is only ever
-        one PoB to create for it (sanity check of the view's own
-        grouping, not just the compute fix)."""
-        self._create_payment_term("Term 1", 15000000)
-        self._create_payment_term("Term 2", 15000000)
-
-        item = self._get_fix_items()
-        self.assertEqual(len(item), 1)
-        self.assertEqual(item.quantity, 2)
-        self.assertEqual(item.amount_untaxed, 30000000)
-
-        item.action_create_pob()
-
-        item = self._get_fix_items()
-        self.assertTrue(item.pob_id)
-        self.assertEqual(item.pob_id.uom_quantity, 2)
-        # price_unit mirrors the item's untaxed amount, per OFS/26/000026
-        # (reverted from a brief per-unit-price change on the same
-        # ticket) -- so it equals the summed amount_untaxed here, not
-        # the per-unit 15000000.
-        self.assertEqual(item.pob_id.price_unit, 30000000)
-        self.assertEqual(item.pob_id.price_subtotal, 60000000)
-
-        item.action_create_pob()
-        self.assertEqual(
-            self.env["performance_obligation"].search_count(
-                [
-                    (
-                        "source_analytic_account_id",
-                        "=",
-                        self.contract.analytic_account_id.id,
-                    ),
-                    ("product_id", "=", self.product.id),
-                    ("price_unit", "=", 30000000),
-                ]
-            ),
-            1,
-            "calling action_create_pob again must not create a duplicate PoB",
-        )
-
-    def test_pob_price_unit_is_amount_untaxed_when_quantity_not_one(self):
-        """OFS/26/000026 (reverted): PoB price_unit = item's
-        amount_untaxed even when quantity != 1 -- reporter confirmed
-        this is the intended setting, accepting that price_subtotal
-        (price_unit * uom_quantity) overstates the true total in this
-        case (15000000 instead of the item's own 5000000)."""
-        self._create_payment_term("Term 1", 5000000, quantity=3)
-
-        item = self._get_fix_items()
-        self.assertEqual(len(item), 1)
-        self.assertEqual(item.price_unit, 5000000)
-        self.assertEqual(item.amount_untaxed, 15000000)
-
-        item.action_create_pob()
-
-        item = self._get_fix_items()
-        self.assertEqual(item.pob_id.price_unit, 15000000)
-        self.assertEqual(item.pob_id.uom_quantity, 3)
-        self.assertEqual(item.pob_id.price_subtotal, 45000000)
-
-        item.action_create_pob()
-        self.assertEqual(
-            self.env["performance_obligation"].search_count(
-                [
-                    (
-                        "source_analytic_account_id",
-                        "=",
-                        self.contract.analytic_account_id.id,
-                    ),
-                    ("product_id", "=", self.product.id),
-                    ("price_unit", "=", 15000000),
-                ]
-            ),
-            1,
-            "calling action_create_pob again must not create a duplicate PoB",
-        )
+    def test_service_contract_fix_item_pob(self):
+        """Run the PoB creation scenarios for ``service.contract_fix_item``."""
+        self.run_yaml_scenario("test_data_service_contract_fix_item_pob.yaml")


### PR DESCRIPTION
## Ringkasan

Price Unit PoB yang dibuat dari `service.contract_fix_item` sekarang memakai harga per-unit **sebelum pajak** (`amount_untaxed / quantity`), bukan harga kontrak yang termasuk pajak (revisi 7 Agustus, PR #99) ataupun total yang sudah dikali quantity (revisi 11 Agustus, PR #101).

Dengan ini `price_subtotal` PoB (`price_unit * uom_quantity`) kembali sama dengan `amount_untaxed` item kontrak walau `quantity != 1` — menyelesaikan OFS/26/000026 (reopened, feedback quantity=2 pada kontrak SVC/2026/000001).

## Test plan

- [x] Unit test baru (`test_data_service_contract_fix_item_pob.yaml`) — verifikasi `price_unit`/`price_subtotal` PoB untuk quantity != 1 dengan pajak tax-inclusive, distinct-price lines, dan idempotensi `action_create_pob`.
- [x] Dijalankan di server lokal (`--test-enable --test-tags /ssi_service_revenue_recognition`): 0 failed, 0 error dari 2 test (termasuk test lama yang tidak tersentuh).