### PR TITLE
[UPD] ssi_service_project

### DIFF
--- a/ssi_service_project/README.rst
+++ b/ssi_service_project/README.rst
@@ -19,6 +19,12 @@ To install this module, you need to:
 5.  Search For *ServicService Quotatione*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/01-create.html>`_
+* `Approve Service Contract <docs/service_contract/05-approve.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_service_project/__manifest__.py
+++ b/ssi_service_project/__manifest__.py
@@ -12,10 +12,12 @@
     "depends": [
         "ssi_service",
         "ssi_project_code",
+        "web_tour",
     ],
     "data": [
         "views/service_type_views.xml",
         "views/service_contract_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_service_project/docs/service_contract/01-create.md
+++ b/ssi_service_project/docs/service_contract/01-create.md
@@ -1,0 +1,16 @@
+# Create Service Contract
+
+> **Module:** ssi_service_project **Extends:** ssi_service — model `service.contract`,
+> aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a new **Project** group (after
+**Analytic & Project**) with two fields:
+
+- **Auto Create Project**: Optional. Automatically filled from **Type**. Change if
+  needed. When checked and **Project** is left empty, a `project.project` record is
+  automatically created once the contract reaches **In Progress** — see `05-approve.md`.
+- **Project**: Optional. Links the contract to an existing `project.project` record.
+  When set, that project is refreshed (instead of a new one being created) once the
+  contract reaches **In Progress**.

--- a/ssi_service_project/docs/service_contract/05-approve.md
+++ b/ssi_service_project/docs/service_contract/05-approve.md
@@ -1,0 +1,12 @@
+# Approve Service Contract
+
+> **Module:** ssi_service_project **Extends:** ssi_service — model `service.contract`,
+> aksi `05-approve`
+
+## Additional Post-Condition
+
+- When **Auto Create Project** is checked, a `project.project` record is automatically
+  created and linked via **Project** once the contract reaches **In Progress** (`open`)
+  — unless **Project** was already set, in which case that existing project is refreshed
+  instead. This is not a Flow step; it runs automatically as part of the same Approve
+  action documented in the base module's `05-approve.md`.

--- a/ssi_service_project/migrations/14.0.2.0.0/pre-migration.py
+++ b/ssi_service_project/migrations/14.0.2.0.0/pre-migration.py
@@ -5,6 +5,17 @@ import logging
 
 
 def migrate(cr, version):
+    """Backfill ``project.project`` name/code from their contract.
+
+    For every ``project.project`` created by an auto-create-project
+    contract, copy the contract's **Title**/**Reference** onto the
+    project's ``name``/``code`` so pre-existing projects match the
+    naming produced by :meth:`_prepare_project_data`.
+
+    :param cr: database cursor
+    :param version: previously installed module version, or a falsy
+        value on a fresh install (in which case this is a no-op)
+    """
     if not version:
         return
     logger = logging.getLogger(__name__)

--- a/ssi_service_project/models/service_contract.py
+++ b/ssi_service_project/models/service_contract.py
@@ -8,6 +8,13 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class ServiceContract(models.Model):
+    """
+    Adds project.project integration to the service contract.
+    Lets a contract auto-create (or refresh) a linked project once it
+    reaches the open state, so project tracking can start without a
+    separate manual step.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",
@@ -25,6 +32,14 @@ class ServiceContract(models.Model):
 
     @ssi_decorator.post_open_action()
     def _11_create_project(self):
+        """Create or refresh the linked project when the contract opens.
+
+        Runs after the contract reaches the ``open`` state (triggered
+        by ``action_approve_approval``). If **Project** is already
+        set, that project is refreshed with :meth:`_prepare_project_data`.
+        Otherwise, when **Auto Create Project** is checked, a new
+        ``project.project`` is created and linked via **Project**.
+        """
         self.ensure_one()
         if self.project_id:
             self.project_id.write(self._prepare_project_data())
@@ -38,6 +53,13 @@ class ServiceContract(models.Model):
             )
 
     def _prepare_project_data(self):
+        """Build the ``project.project`` values for this contract.
+
+        Extension point: override to add or change the fields copied
+        from the contract onto the generated/refreshed project.
+
+        :return: dict of ``project.project`` values
+        """
         self.ensure_one()
         return {
             "name": self.title,

--- a/ssi_service_project/models/service_type.py
+++ b/ssi_service_project/models/service_type.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 
 
 class ServiceType(models.Model):
+    """
+    Adds the auto project creation default to the service type.
+    The value configured here is copied onto a new service contract's
+    ``auto_create_project`` field via onchange when **Type** is
+    selected.
+    """
+
     _name = "service.type"
     _inherit = [
         "service.type",

--- a/ssi_service_project/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_project/static/tests/tours/service_contract_tour.js
@@ -55,8 +55,13 @@ odoo.define("ssi_service_project.service_contract_tour", function (require) {
             // Additional Fields (docs/service_contract/01-create.md,
             // delta of ssi_service_project) — the Auto Create Project
             // and Project fields added by this module are rendered on
-            // the create form. Delta-only tour: it stops here, it
-            // does not fill any field and does not continue to Save.
+            // the create form, inside the "Analytic & Project" tab.
+            // Delta-only tour: it stops here, it does not fill any
+            // field and does not continue to Save.
+            {
+                content: "Open the Analytic & Project tab",
+                trigger: ".o_notebook .nav-link:contains(Analytic & Project)",
+            },
             {
                 content: "Auto Create Project field is displayed",
                 trigger: ".o_field_widget[name='auto_create_project']",

--- a/ssi_service_project/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_project/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,76 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_project.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields)
+    tour.register(
+        "ssi_service_project_service_contract_field_auto_create_project",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md,
+            // delta of ssi_service_project) — the Auto Create Project
+            // and Project fields added by this module are rendered on
+            // the create form. Delta-only tour: it stops here, it
+            // does not fill any field and does not continue to Save.
+            {
+                content: "Auto Create Project field is displayed",
+                trigger: ".o_field_widget[name='auto_create_project']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Project field is displayed",
+                trigger: ".o_field_widget[name='project_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_project/tests/__init__.py
+++ b/ssi_service_project/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_project
+from . import test_ui_service_contract

--- a/ssi_service_project/tests/test_data_service_project.yaml
+++ b/ssi_service_project/tests/test_data_service_project.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Project - Create and Verify with Auto Project"
     steps:
@@ -63,11 +66,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
-
       - step: "Approve contract"
         action: "call"
         target: "contract"
@@ -77,11 +75,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate cache after approve"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Assert project created"
         action: "assert"

--- a/ssi_service_project/tests/test_service_project.py
+++ b/ssi_service_project/tests/test_service_project.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceProject(YamlTransactionCase):
+    """Cover the ``service.contract`` auto project creation feature."""
+
     def test_service_project(self):
+        """Run the auto create project scenario."""
         self.run_yaml_scenario("test_data_service_project.yaml")

--- a/ssi_service_project/tests/test_ui_service_contract.py
+++ b/ssi_service_project/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` auto project delta."""
+
+    def test_field_auto_create_project(self):
+        """Run the delta tour for the ``service.contract`` create form.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_project_service_contract_field_auto_create_project",
+            login="admin",
+        )

--- a/ssi_service_project/views/assets.xml
+++ b/ssi_service_project/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_project assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_project/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 12 temuan audit kepatuhan (ERROR) pada modul `ssi_service_project` tanpa
mengubah perilaku modul yang sudah berjalan:

* Docstring lengkap (reST, Inggris, ≤79 karakter) pada seluruh class & method yang
  belum terdokumentasi — model (`ServiceContract`, `ServiceType`), migrasi
  (`migrate`), dan berkas test (`TestServiceProject`, `test_service_project`).
* `invalidate_cache` manual pada skenario unit test (`test_data_service_project.yaml`)
  dihapus, diganti opsi `auto_refresh` milik pustaka `odoo-yaml-test`. Assertion yang
  sudah ada tidak diubah.
* Instruksi Kerja (IK) extension untuk model `service.contract` ditambahkan —
  `docs/service_contract/01-create.md` (Additional Fields: **Auto Create Project**,
  **Project**) dan `docs/service_contract/05-approve.md` (Additional Post-Condition:
  pembuatan/refresh project otomatis) — beserta tour UI pasangan
  (`static/tests/tours/service_contract_tour.js` + `tests/test_ui_service_contract.py`).

## Verifikasi

Keempat validator kepatuhan modul lolos `status=OK` (`error=0`):

```
#VALIDATOR name=module    target=ssi_service_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_project series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_project series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`pre-commit-gate.sh` mencetak `GATE OK: 6 pemeriksaan, 0 pelanggaran baru.`

Sisa peringatan (`!`) di luar lingkup issue ini (cakupan `@api.onchange` di unit-test,
dan tour pasangan untuk `05-approve.md` yang memang `## Additional Post-Condition`
tanpa langkah tour per `modul-extension.md`).

Closes #109