### PR TITLE
[UPD] ssi_service_revenue_recognition - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_revenue_recognition/README.rst
+++ b/ssi_service_revenue_recognition/README.rst
@@ -1,0 +1,41 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============================
+Service - Revenue Recognition
+=============================
+
+
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/index.html>`_
+* `Edit Service Contract <docs/service_contract/index.html>`_
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/open-synergy/opnsynid-service/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://simetri-sinergi.id/logo.png
+   :alt: PT. Simetri Sinergi Indonesia
+   :target: https://simetri-sinergi.id
+
+This module is maintained by the PT. Simetri Sinergi Indonesia.

--- a/ssi_service_revenue_recognition/__manifest__.py
+++ b/ssi_service_revenue_recognition/__manifest__.py
@@ -13,9 +13,11 @@
     "depends": [
         "ssi_service",
         "ssi_revenue_recognition",
+        "web_tour",
     ],
     "data": [
         "views/service_type_views.xml",
         "views/service_contract_views.xml",
+        "views/assets.xml",
     ],
 }

--- a/ssi_service_revenue_recognition/docs/service_contract/01-create.md
+++ b/ssi_service_revenue_recognition/docs/service_contract/01-create.md
@@ -1,0 +1,26 @@
+# Create Service Contract
+
+> **Module:** ssi_service_revenue_recognition\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`
+
+## Additional Fields
+
+On the **Analytic & Project** tab, this module adds two fields:
+
+- **PoB Analytic Group**: Optional. The analytic group used when Performance Obligations
+  are auto-created from this contract's fix items. Defaults from the selected **Type**'s
+  own PoB Analytic Group whenever **Type** changes, but may be changed afterwards.
+- **Analytic Budget**: Optional. The analytic budget this contract's Performance
+  Obligations are tracked against. Editable unless the budget is locked — see **Lock
+  Budget** in `02-edit`.
+
+## Related Views
+
+- A **Performance Obligations** tab is added to the form, showing **Total** and
+  **Diff.** (this contract's own untaxed amount versus the total amount of Performance
+  Obligations already created from it, both read-only) and the list of those Performance
+  Obligations. Clicking **PoB(s)** opens the full list in its own view. This tab has
+  nothing to fill in and is not a Flow step.
+- A **PoB Cost/Rev** smart button (`action_open_pob_cost_revenue`) is added to the
+  button box. It opens the analytic lines posted to this contract's Performance
+  Obligations' own analytic accounts. Navigation only; nothing is written.

--- a/ssi_service_revenue_recognition/docs/service_contract/02-edit.md
+++ b/ssi_service_revenue_recognition/docs/service_contract/02-edit.md
@@ -1,0 +1,31 @@
+# Edit Service Contract
+
+> **Module:** ssi_service_revenue_recognition\
+> **Extends:** ssi_service — model `service.contract`, aksi `02-edit`\
+> **Inline Actions:** `action_create_pob` (gear icon button on the Items table),
+> `action_lock_budget` (Lock Budget), `action_unlock_budget` (Unlock Budget)
+
+## Additional Fields
+
+See `01-create` for **PoB Analytic Group** and **Analytic Budget** — both remain
+editable while editing an existing contract, subject to the Lock Budget state described
+below.
+
+## Modified Flow
+
+- Anchor: on the Flow base's step _Change any of the fields described in `01-create`_,
+  on the **Contract Items** tab, the read-only **Items** summary table gains a gear-icon
+  button on each row. Clicking it creates a Performance Obligation for that row's
+  product/price if one does not already exist yet (the row's **# PoB** column stays
+  empty until then). This button is not restricted to a particular contract status, but
+  the Performance Obligation it creates is only correctly linked to this contract's own
+  analytic account once that account exists — which happens when the contract reaches
+  **In Progress** (see the base module's `05-approve.md`). Optional: creating
+  Performance Obligations is not required to Save or to progress the contract's own
+  status; skipping it just leaves the Performance Obligations tab without a
+  corresponding entry for that item.
+- Anchor: on the same Flow base step, on the **Analytic & Project** tab, once an
+  **Analytic Budget** has been selected, click **Lock Budget** to prevent **Analytic
+  Budget** from being changed further (the field becomes read-only). Click **Unlock
+  Budget** to allow changing it again. Neither button is restricted to a particular
+  contract status.

--- a/ssi_service_revenue_recognition/models/service_contract.py
+++ b/ssi_service_revenue_recognition/models/service_contract.py
@@ -8,6 +8,14 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class ServiceContract(models.Model):
+    """Add Performance Obligation revenue recognition to service contract.
+
+    Links a contract's analytic account to the Performance Obligations
+    (PoB) generated from its fix items, tracks the total PoB amount
+    against the contract's own untaxed amount, and lets the budget be
+    locked once it should no longer be recomputed from fix items.
+    """
+
     _name = "service.contract"
     _inherit = ["service.contract"]
 
@@ -48,6 +56,12 @@ class ServiceContract(models.Model):
 
     @api.depends("analytic_account_id")
     def _compute_pob_ids(self):
+        """Resolve the Performance Obligations sourced from this contract.
+
+        Searches ``performance_obligation`` by
+        ``source_analytic_account_id`` since a PoB does not itself point
+        back to the contract that generated it.
+        """
         PoB = self.env["performance_obligation"]
         for record in self:
             if record.analytic_account_id:
@@ -62,6 +76,11 @@ class ServiceContract(models.Model):
         "amount_untaxed",
     )
     def _compute_amount_diff_pob(self):
+        """Compare the contract's untaxed amount against total PoB amount.
+
+        A positive result means the contract's fix items have not yet
+        been fully turned into Performance Obligations.
+        """
         for record in self:
             record.amount_diff_pob = (
                 record.amount_untaxed - record.analytic_account_id.amount_total_pob
@@ -83,22 +102,30 @@ class ServiceContract(models.Model):
             self.analytic_account_id.group_id = self.pob_analytic_group_id
 
     def action_lock_budget(self):
+        """Lock the contract's budget so it stops being recomputed."""
         for record in self.sudo():
             record._lock_budget()
 
     def action_unlock_budget(self):
+        """Unlock the contract's budget so it can be recomputed again."""
         for record in self.sudo():
             record._unlock_budget()
 
     def _lock_budget(self):
+        """Set ``lock_budget`` to ``True`` on this single contract."""
         self.ensure_one()
         self.write({"lock_budget": True})
 
     def _unlock_budget(self):
+        """Set ``lock_budget`` to ``False`` on this single contract."""
         self.ensure_one()
         self.write({"lock_budget": False})
 
     def action_open_pob(self):
+        """Open Performance Obligations sourced from this contract.
+
+        :return: ``ir.actions.act_window`` dict on ``performance_obligation``
+        """
         self.ensure_one()
         result = {
             "name": "Performance Obligations",

--- a/ssi_service_revenue_recognition/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition/models/service_contract_fix_item.py
@@ -7,6 +7,13 @@ from odoo.exceptions import UserError
 
 
 class ServiceContractFixItem(models.Model):
+    """Add Performance Obligation (PoB) creation to fix item lines.
+
+    Each fix item line can be turned into a Performance Obligation
+    for revenue recognition; ``pob_id`` resolves the PoB already
+    created for a line (if any), and ``action_create_pob`` creates it.
+    """
+
     _name = "service.contract_fix_item"
     _inherit = "service.contract_fix_item"
 
@@ -86,10 +93,16 @@ class ServiceContractFixItem(models.Model):
         return self.amount_untaxed / self.quantity
 
     def action_create_pob(self):
+        """Create the Performance Obligation for each selected line."""
         for record in self.sudo():
             record._create_pob()
 
     def _create_pob(self):
+        """Create the PoB for this single line, unless one already exists.
+
+        Extension point: override ``_prepare_pob_data`` to change what
+        gets written on the created ``performance_obligation`` record.
+        """
         self.ensure_one()
         if self.pob_id:
             return True
@@ -108,6 +121,15 @@ class ServiceContractFixItem(models.Model):
         self.invalidate_cache(fnames=["pob_id"], ids=self.ids)
 
     def _prepare_pob_data(self):
+        """Build the ``performance_obligation`` values for this line.
+
+        Extension point: override to add/change fields on the PoB
+        created by ``_create_pob``.
+
+        :return: dict of ``performance_obligation`` values
+        :raises UserError: if the manual fulfillment field reference
+            from ``ssi_revenue_recognition`` cannot be resolved
+        """
         self.ensure_one()
         xmlid = (
             "ssi_revenue_recognition."

--- a/ssi_service_revenue_recognition/models/service_type.py
+++ b/ssi_service_revenue_recognition/models/service_type.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 
 
 class ServiceType(models.Model):
+    """Add Performance Obligation defaults to service type.
+
+    Configures the default analytic group used when a contract of
+    this type creates its Performance Obligations, and which products
+    or product categories should have their PoB auto-created.
+    """
+
     _name = "service.type"
     _inherit = [
         "service.type",

--- a/ssi_service_revenue_recognition/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_revenue_recognition/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,194 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_revenue_recognition.service_contract_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    function openContractsMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ];
+    }
+
+    function openRecordSteps(title) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + title + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields, on the Analytic & Project tab).
+    tour.register(
+        "ssi_service_revenue_recognition_service_contract_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openContractsMenuSteps(), [
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // The new fields live on the Analytic & Project tab, which is
+            // NOT the default active tab (Contract Items is first) — it
+            // must be opened before asserting field visibility, otherwise
+            // the fields are in the DOM but not :visible and the trigger
+            // times out.
+            {
+                content: "Open the Analytic & Project tab",
+                trigger: ".o_notebook .nav-link:contains(Analytic & Project)",
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md) —
+            // delta-only tour: it stops here, it does not fill any field
+            // and does not continue to Save.
+            {
+                content: "PoB Analytic Group field is displayed",
+                trigger: ".o_field_widget[name='pob_analytic_group_id']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Analytic Budget field is displayed",
+                trigger: ".o_field_widget[name='analytic_budget_id']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/service_contract/02-edit.md (E2a delta — Modified Flow +
+    // Inline Actions on an existing, already-open contract).
+    tour.register(
+        "ssi_service_revenue_recognition_service_contract_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openContractsMenuSteps(), openRecordSteps("TOUR SC RR Edit"), [
+            // Base Flow — Click Edit (14.0 opens existing records
+            // readonly).
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Modified Flow — Contract Items tab is the default
+            // active tab, no tab click needed for the gear button.
+            {
+                content: "Click Create PoB on the fix item row",
+                trigger:
+                    ".o_field_widget[name='fix_item_ids'] " +
+                    ".o_data_row:contains(TOUR RR Product) " +
+                    "button[name='action_create_pob']",
+            },
+            {
+                // Gate: Odoo 14 disables a type="object" button
+                // synchronously on click and only re-enables it once
+                // the full RPC + form reload cycle completes
+                // (patterns.md §M/§P) — this cannot be true before
+                // the click finishes its round trip, regardless of
+                // whether a Performance Obligation was actually
+                // created (no value is asserted here).
+                content: "Create PoB finished",
+                trigger:
+                    ".o_field_widget[name='fix_item_ids'] " +
+                    ".o_data_row:contains(TOUR RR Product) " +
+                    "button[name='action_create_pob']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Modified Flow — Lock/Unlock Budget live on the
+            // Analytic & Project tab, which is NOT the default
+            // active tab.
+            {
+                content: "Open the Analytic & Project tab",
+                trigger: ".o_notebook .nav-link:contains(Analytic & Project)",
+            },
+            {
+                content: "Lock Budget button is displayed",
+                trigger: ".o_form_view button[name='action_lock_budget']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click Lock Budget",
+                trigger: ".o_form_view button[name='action_lock_budget']",
+            },
+            {
+                // Gate: Unlock Budget only becomes visible once
+                // lock_budget flips to True — it cannot be visible
+                // before Lock Budget is clicked.
+                content: "Unlock Budget button is now displayed",
+                trigger: ".o_form_view button[name='action_unlock_budget']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Lock Budget button is no longer displayed",
+                trigger:
+                    ".o_form_view:not(:has(button[name='action_lock_budget']:visible))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_service_revenue_recognition/tests/__init__.py
+++ b/ssi_service_revenue_recognition/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_service_contract_fix_item_pob
 from . import test_service_contract_pob_cost_revenue
+from . import test_ui_service_contract

--- a/ssi_service_revenue_recognition/tests/test_ui_service_contract.py
+++ b/ssi_service_revenue_recognition/tests/test_ui_service_contract.py
@@ -1,0 +1,136 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` revenue recognition delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an open contract with one fix item, for the edit tour.
+
+        The create tour (E1 delta-only) needs no fixture at all -- it
+        opens a blank create form. The edit tour needs an existing
+        contract that already reached ``open`` (so it has its own
+        Analytic Account, matching how ``action_create_pob`` is meant
+        to be used -- see ``docs/service_contract/02-edit.md``) and at
+        least one fix item row (from a payment term detail line) for
+        the Create PoB gear button to act on.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        income_account = cls.env["account.account"].search(
+            [("user_type_id.internal_group", "=", "income")], limit=1
+        )
+        uom = cls.env.ref("uom.product_uom_unit")
+        pricelist = cls.env.ref("product.list0")
+        partner = (
+            cls.env["res.partner"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "TOUR RR Partner",
+                    "is_company": True,
+                }
+            )
+        )
+        service_type = (
+            cls.env["service.type"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "TOUR RR Service Type",
+                    "code": "TOURRR",
+                }
+            )
+        )
+        product = (
+            cls.env["product.product"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "TOUR RR Product",
+                    "type": "service",
+                    "uom_id": uom.id,
+                    "uom_po_id": uom.id,
+                }
+            )
+        )
+        cls.contract = (
+            cls.env["service.contract"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "title": "TOUR SC RR Edit",
+                    "partner_id": partner.id,
+                    "type_id": service_type.id,
+                    "manager_id": cls.admin.id,
+                    "salesperson_id": cls.admin.id,
+                    "pricelist_id": pricelist.id,
+                    "currency_id": cls.env.ref("base.USD").id,
+                    "date": "2026-01-01",
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-12-31",
+                }
+            )
+        )
+        cls.contract.with_user(cls.admin).action_confirm()
+        cls.contract.with_user(cls.admin).with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        cls.contract.invalidate_cache()
+        term = (
+            cls.env["service.contract_fix_item_payment_term"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "service_id": cls.contract.id,
+                    "name": "TOUR RR Term",
+                    "sequence": 10,
+                }
+            )
+        )
+        cls.env["service.contract_fix_item_payment_term_detail"].with_user(
+            cls.admin
+        ).create(
+            {
+                "term_id": term.id,
+                "product_id": product.id,
+                "name": product.name,
+                "account_id": income_account.id,
+                "price_unit": 500,
+                "quantity": 1,
+                "uom_quantity": 1,
+                "uom_id": uom.id,
+                "sequence": 10,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``service.contract``.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_revenue_recognition_service_contract_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``service.contract``.
+
+        IK: docs/service_contract/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_revenue_recognition_service_contract_edit",
+            login="admin",
+        )

--- a/ssi_service_revenue_recognition/views/assets.xml
+++ b/ssi_service_revenue_recognition/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_revenue_recognition assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_revenue_recognition/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 17 butir temuan audit ERROR pada modul `ssi_service_revenue_recognition`
(sapuan `audit-sweep.sh 14.0 --repo opnsynid-service`, 14 Agustus 2026):

* Tambah `README.rst` (badge lisensi AGPL-3, bagian Work Instruction menunjuk IK modul ini)
* Tambah docstring reST (bahasa Inggris, ≤ 79 karakter) untuk seluruh class & method di
  `models/service_contract.py`, `models/service_contract_fix_item.py`,
  `models/service_type.py` yang belum memilikinya
* Tambah Instruksi Kerja extension di `docs/service_contract/` (`01-create.md`,
  `02-edit.md`) beserta tour UI pasangannya
  (`static/tests/tours/service_contract_tour.js`, `tests/test_ui_service_contract.py`)
* Direktori `tests/` (skenario `odoo-yaml-test`) sudah ada dari perbaikan sebelumnya dan
  terdaftar di `tests/__init__.py`

Tidak ada perubahan perilaku modul yang sudah berjalan — hanya dokumentasi, docstring,
IK, dan tour.

## Hasil validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_service_revenue_recognition series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_revenue_recognition series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_revenue_recognition series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_revenue_recognition series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_revenue_recognition series=14.0 error=0 warn=2 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_revenue_recognition series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

2 peringatan `unit-test` (cakupan onchange & transisi action_lock_budget/unlock_budget)
sengaja di luar lingkup issue ini (lihat `## Tidak termasuk` di issue).

## Test plan

- [x] `verify-module.sh`, `validate-ik.sh`, `validate-po.sh`, `validate-web.sh`,
      `validate-unit-test.sh`, `validate-tour.sh` — keenamnya `status=OK`
- [x] `pre-commit-gate.sh` — `GATE OK`
- [ ] CI hijau

Closes #123