### PR TITLE
[UPD] ssi_service_contract_tnc - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_contract_tnc/README.rst
+++ b/ssi_service_contract_tnc/README.rst
@@ -7,6 +7,12 @@ Service Contract - T&C Integration
 ==================================
 
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_contract_tnc/__manifest__.py
+++ b/ssi_service_contract_tnc/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2024 OpenSynergy Indonesia
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
+# pylint: disable=locally-disabled, manifest-required-author
 {
     "name": "Service Contract - T&C Integration",
     "version": "14.0.1.0.0",
@@ -11,8 +12,11 @@
     "depends": [
         "ssi_service",
         "ssi_term_condition_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_contract_tnc/docs/service_contract/01-create.md
+++ b/ssi_service_contract_tnc/docs/service_contract/01-create.md
@@ -1,0 +1,24 @@
+# Create Service Contract
+
+> **Module:** ssi_service_contract_tnc\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`\
+> **Inline Actions:** `action_generate_tnc` (Generate T&C)
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Terms & Conditions** tab:
+
+- **T&C Template**: Optional. Selects a `tnc_template` record configured for the
+  `service.contract` model. Selecting a template does not by itself fill in the
+  **Sections** / **Clauses** lists below — click **Generate T&C** (see below).
+- **Sections**: A list of T&C sections attached to the contract. Rows may be added
+  manually with **Add a line**, or generated in bulk from **T&C Template** with
+  **Generate T&C**.
+- **Clauses**: Read-only. Automatically aggregated from the clauses of every row in
+  **Sections** — not filled directly by the user.
+
+On the **Terms & Conditions** tab, click **Generate T&C** to (re)build **Sections**
+(and, through it, **Clauses**) from the selected **T&C Template**. Running it again
+after changing **T&C Template** first discards the sections generated previously, then
+rebuilds them from the new template. If **T&C Template** is empty, **Generate T&C**
+discards any existing sections and leaves the lists empty — it does not fail.

--- a/ssi_service_contract_tnc/models/service_contract.py
+++ b/ssi_service_contract_tnc/models/service_contract.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class ServiceContract(models.Model):
+    """Attach Terms & Conditions to ``service.contract``.
+
+    Inherits ``mixin.tnc`` and enables its auto-injected form page
+    (``_tnc_create_page = True``), giving each service contract a
+    ``T&C Template`` field plus generated sections/clauses. See the
+    ``mixin.tnc`` docstring for the fields and the ``Generate T&C``
+    action it contributes.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",

--- a/ssi_service_contract_tnc/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_contract_tnc/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,86 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_contract_tnc.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields + Inline Actions: action_generate_tnc)
+    tour.register(
+        "ssi_service_contract_tnc_service_contract_field_tnc",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md,
+            // delta of ssi_service_contract_tnc) — the Terms &
+            // Conditions tab added by mixin.tnc. Open it first: the
+            // tab is not the active one by default (patterns.md §
+            // notebook tabs).
+            {
+                content: "Open the Terms & Conditions tab",
+                trigger: ".o_notebook .nav-link:contains(Terms & Conditions)",
+            },
+
+            // Delta-only tour: assert the T&C Template field and the
+            // Generate T&C button are present, then stop. It does not
+            // fill any field and does not continue to Save (E1
+            // delta-only; see odoo-development-ui-test
+            // scope-and-boundaries.md).
+            {
+                content: "T&C Template field is displayed",
+                trigger: ".o_field_widget[name='tnc_template_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Generate T&C button is displayed",
+                trigger: "button[name='action_generate_tnc']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_contract_tnc/tests/__init__.py
+++ b/ssi_service_contract_tnc/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_contract_tnc
+from . import test_ui_service_contract

--- a/ssi_service_contract_tnc/tests/test_data_service_contract_tnc.yaml
+++ b/ssi_service_contract_tnc/tests/test_data_service_contract_tnc.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Contract TnC - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_contract_tnc/tests/test_service_contract_tnc.py
+++ b/ssi_service_contract_tnc/tests/test_service_contract_tnc.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceContractTnc(YamlTransactionCase):
+    """YAML scenario test for the ``service.contract`` T&C mixin."""
+
     def test_service_contract_tnc(self):
+        """Run the create/confirm/approve T&C scenario."""
         self.run_yaml_scenario("test_data_service_contract_tnc.yaml")

--- a/ssi_service_contract_tnc/tests/test_ui_service_contract.py
+++ b/ssi_service_contract_tnc/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` T&C delta."""
+
+    def test_field_tnc(self):
+        """Run the delta tour for the ``service.contract`` create form.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_contract_tnc_service_contract_field_tnc",
+            login="admin",
+        )

--- a/ssi_service_contract_tnc/views/assets.xml
+++ b/ssi_service_contract_tnc/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_contract_tnc assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_contract_tnc/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan audit kepatuhan (`audit-sweep.sh 14.0 --repo opnsynid-service`)
pada modul `ssi_service_contract_tnc`, tanpa mengubah perilaku modul yang sudah berjalan:

* Tambah docstring reST untuk class `ServiceContract` dan class/method test yang belum
  punya docstring (`setiap-class-method-punya-docstring`, `setiap-class-method-test-punya-docstring`).
* Hapus `invalidate_cache` manual pada skenario YAML, ganti dengan opsi auto-refresh cache
  (`options: {auto_refresh: true}`) milik `odoo-yaml-test` (`tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh`).
* Tambah Instruksi Kerja extension `docs/service_contract/01-create.md` (modul ini
  meng-`_inherit` `service.contract` dari `ssi_service`, jadi IK hanya mendokumentasikan
  field & aksi TAMBAHAN dari `mixin.tnc`: field **T&C Template**, list **Sections** /
  **Clauses**, dan tombol inline **Generate T&C**), beserta tour UI test pasangannya
  (`modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali`).

Tidak ada perubahan field/model/nama class/method, dan tidak ada assertion unit test yang
dilonggarkan atau dihapus.

Closes #104

## Test plan

- [x] `verify-module.sh ssi_service_contract_tnc 14.0` → `LOLOS: 0 ERROR`
- [x] `validate-unit-test.sh ssi_service_contract_tnc 14.0` → `LOLOS: 0 ERROR`
- [x] `validate-ik.sh ssi_service_contract_tnc` → `LOLOS: 0 ERROR`
- [x] `validate-tour.sh ssi_service_contract_tnc 14.0` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI hijau (menyusul)

🤖 Generated with [Claude Code](https://claude.com/claude-code)