### PR TITLE
[UPD] ssi_service_revenue_recognition_project - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_revenue_recognition_project/README.rst
+++ b/ssi_service_revenue_recognition_project/README.rst
@@ -1,0 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================================
+Service - Revenue Recognition + Project Integration
+===================================================
+
+
+Work Instruction
+================
+
+* `Edit Service Contract <docs/service_contract/index.html>`_
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/open-synergy/opnsynid-service/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://simetri-sinergi.id/logo.png
+   :alt: PT. Simetri Sinergi Indonesia
+   :target: https://simetri-sinergi.id
+
+This module is maintained by the PT. Simetri Sinergi Indonesia.

--- a/ssi_service_revenue_recognition_project/docs/service_contract/02-edit.md
+++ b/ssi_service_revenue_recognition_project/docs/service_contract/02-edit.md
@@ -1,0 +1,16 @@
+# Edit Service Contract
+
+> **Module:** ssi_service_revenue_recognition_project\
+> **Extends:** ssi_service_revenue_recognition — model `service.contract`, aksi `02-edit`
+
+## Additional Post-Condition
+
+- When the Inline Action `action_create_pob` (gear icon button on the Items table,
+  documented in the base extension's `02-edit.md`) creates a Performance Obligation for
+  a fix item line, the resulting `performance_obligation` record's own **Auto Create
+  Project** field is defaulted from this contract's **Type**'s own **Auto Create Project
+  on PoB** field — a new checkbox this module adds to the **Service Type** form. This is
+  not a Flow step; it happens automatically as part of the same `action_create_pob`
+  click. The Performance Obligation's **Auto Create Project** field and the project
+  auto-creation itself are provided by module `ssi_revenue_recognition_project`, not
+  part of this repository.

--- a/ssi_service_revenue_recognition_project/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition_project/models/service_contract_fix_item.py
@@ -6,12 +6,27 @@ from odoo import models
 
 
 class ServiceContractFixItem(models.Model):
+    """Add the Type's auto-create-project default to PoB creation.
+
+    Extends ``_prepare_pob_data`` so a Performance Obligation created
+    from this fix item line carries the contract's own Type's
+    ``pob_auto_create_project`` value, letting
+    ``ssi_revenue_recognition_project`` decide whether to auto-create
+    a project once that Performance Obligation is confirmed.
+    """
+
     _name = "service.contract_fix_item"
     _inherit = [
         "service.contract_fix_item",
     ]
 
     def _prepare_pob_data(self):
+        """Add ``auto_create_project`` on top of the base PoB values.
+
+        :return: dict of ``performance_obligation`` values, extending
+            the base ``_prepare_pob_data`` result with
+            ``auto_create_project`` sourced from ``service_id.type_id``
+        """
         self.ensure_one()
         _super = super(ServiceContractFixItem, self)
         result = _super._prepare_pob_data()

--- a/ssi_service_revenue_recognition_project/models/service_type.py
+++ b/ssi_service_revenue_recognition_project/models/service_type.py
@@ -6,6 +6,14 @@ from odoo import fields, models
 
 
 class ServiceType(models.Model):
+    """Add the Auto Create Project on PoB default to service type.
+
+    The value configured here becomes the ``auto_create_project``
+    default written onto a Performance Obligation created from one of
+    this type's contracts' fix items — see
+    ``service.contract_fix_item._prepare_pob_data``.
+    """
+
     _name = "service.type"
     _inherit = [
         "service.type",

--- a/ssi_service_revenue_recognition_project/tests/__init__.py
+++ b/ssi_service_revenue_recognition_project/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_service_contract_fix_item_pob

--- a/ssi_service_revenue_recognition_project/tests/test_data_service_contract_fix_item_pob.yaml
+++ b/ssi_service_revenue_recognition_project/tests/test_data_service_contract_fix_item_pob.yaml
@@ -1,0 +1,321 @@
+scenarios:
+  - name: "PoB auto_create_project is True when Type has it checked"
+    steps:
+      - step: "Get income account"
+        action: "search"
+        model: "account.account"
+        domain: [["user_type_id.internal_group", "=", "income"]]
+        save_as: "income_account"
+        limit: 1
+
+      - step: "Get generic unit of measure"
+        action: "ref"
+        xml_id: "uom.product_uom_unit"
+        save_as: "uom"
+
+      - step: "Get default pricelist"
+        action: "ref"
+        xml_id: "product.list0"
+        save_as: "pricelist"
+
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB auto_create_project True"
+          is_company: true
+
+      - step: "Create test service type with PoB auto-create-project checked"
+        action: "create"
+        model: "service.type"
+        save_as: "service_type"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Service Type - auto_create_project True"
+          code: "POBACPT"
+          pob_auto_create_project: true
+
+      - step: "Create test product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lumpsum Service - auto_create_project True"
+          type: "service"
+          uom_id: "REC: uom.id"
+          uom_po_id: "REC: uom.id"
+
+      - step: "Create service contract"
+        action: "create"
+        model: "service.contract"
+        save_as: "contract"
+        as_user: "base.user_admin"
+        values:
+          title: "Test Service Contract - auto_create_project True"
+          partner_id: "REC: partner.id"
+          type_id: "REC: service_type.id"
+          manager_id: "REF: base.user_admin"
+          salesperson_id: "REF: base.user_admin"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          date: "2026-01-01"
+          date_start: "2026-01-01"
+          date_end: "2026-12-31"
+
+      - step: "Confirm contract"
+        action: "call"
+        target: "contract"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Assert confirmed (forces refresh before approve reads policy)"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve contract (opens it, auto-creates analytic account)"
+        action: "call"
+        target: "contract"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Assert contract open with its own analytic account"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "service.contract_fix_item_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          service_id: "REC: contract.id"
+          name: "Term 1"
+          sequence: 10
+
+      - step: "Create payment term detail"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 500
+          quantity: 1
+          uom_quantity: 1
+          uom_id: "REC: uom.id"
+          sequence: 10
+
+      - step: "Fetch the contract fix item view row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "item"
+        refresh: true
+        expect_count: 1
+
+      - step: "Create the PoB from the item"
+        action: "call"
+        target: "item"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Fetch the created PoB"
+        action: "search"
+        model: "performance_obligation"
+        domain:
+          - ["source_analytic_account_id", "=", "REC: contract.analytic_account_id.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "pob"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert PoB auto_create_project matches Type's checked flag"
+        action: "assert"
+        target: "pob"
+        asserts:
+          auto_create_project:
+            type: "value"
+            expected: true
+
+  - name: "PoB auto_create_project is False when Type does not have it checked"
+    steps:
+      - step: "Get income account"
+        action: "search"
+        model: "account.account"
+        domain: [["user_type_id.internal_group", "=", "income"]]
+        save_as: "income_account"
+        limit: 1
+
+      - step: "Get generic unit of measure"
+        action: "ref"
+        xml_id: "uom.product_uom_unit"
+        save_as: "uom"
+
+      - step: "Get default pricelist"
+        action: "ref"
+        xml_id: "product.list0"
+        save_as: "pricelist"
+
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB auto_create_project False"
+          is_company: true
+
+      - step: "Create test service type without PoB auto-create-project"
+        action: "create"
+        model: "service.type"
+        save_as: "service_type"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Service Type - auto_create_project False"
+          code: "POBACPF"
+
+      - step: "Create test product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lumpsum Service - auto_create_project False"
+          type: "service"
+          uom_id: "REC: uom.id"
+          uom_po_id: "REC: uom.id"
+
+      - step: "Create service contract"
+        action: "create"
+        model: "service.contract"
+        save_as: "contract"
+        as_user: "base.user_admin"
+        values:
+          title: "Test Service Contract - auto_create_project False"
+          partner_id: "REC: partner.id"
+          type_id: "REC: service_type.id"
+          manager_id: "REF: base.user_admin"
+          salesperson_id: "REF: base.user_admin"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          date: "2026-01-01"
+          date_start: "2026-01-01"
+          date_end: "2026-12-31"
+
+      - step: "Confirm contract"
+        action: "call"
+        target: "contract"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Assert confirmed (forces refresh before approve reads policy)"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve contract (opens it, auto-creates analytic account)"
+        action: "call"
+        target: "contract"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Assert contract open with its own analytic account"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "service.contract_fix_item_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          service_id: "REC: contract.id"
+          name: "Term 1"
+          sequence: 10
+
+      - step: "Create payment term detail"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 500
+          quantity: 1
+          uom_quantity: 1
+          uom_id: "REC: uom.id"
+          sequence: 10
+
+      - step: "Fetch the contract fix item view row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "item"
+        refresh: true
+        expect_count: 1
+
+      - step: "Create the PoB from the item"
+        action: "call"
+        target: "item"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Fetch the created PoB"
+        action: "search"
+        model: "performance_obligation"
+        domain:
+          - ["source_analytic_account_id", "=", "REC: contract.analytic_account_id.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "pob"
+        refresh: true
+        expect_count: 1
+
+      - step: "Assert PoB auto_create_project stays False by default"
+        action: "assert"
+        target: "pob"
+        asserts:
+          auto_create_project:
+            type: "value"
+            expected: false

--- a/ssi_service_revenue_recognition_project/tests/test_service_contract_fix_item_pob.py
+++ b/ssi_service_revenue_recognition_project/tests/test_service_contract_fix_item_pob.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestServiceContractFixItemPob(YamlTransactionCase):
+    """Covers the ``auto_create_project`` default on PoB creation.
+
+    ``service.contract_fix_item._prepare_pob_data`` (this module) adds
+    ``auto_create_project`` to the Performance Obligation values, sourced
+    from ``service_id.type_id.pob_auto_create_project``. Both branches of
+    that boolean default are covered here (``True`` and the ``False``
+    default); this module does not add any ``@api.constrains``, so there
+    is no negative ``expect_error`` path to cover.
+    """
+
+    def test_service_contract_fix_item_pob(self):
+        """Run the ``auto_create_project`` default scenarios."""
+        self.run_yaml_scenario("test_data_service_contract_fix_item_pob.yaml")


### PR DESCRIPTION
## Ringkasan

Memperbaiki 6 temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service`
pada modul `ssi_service_revenue_recognition_project`:

* `modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali` — ditambahkan IK extension
  `docs/service_contract/02-edit.md` (mendokumentasikan efek tambahan `action_create_pob`:
  default `auto_create_project` dari Type ke Performance Obligation yang dibuat).
* `readme-rst-ada` — ditambahkan `README.rst`.
* `setiap-class-method-punya-docstring` (3 butir) — docstring ditambahkan pada
  `ServiceContractFixItem`, `ServiceType`, dan `_prepare_pob_data`.
* `modul-yang-mendefinisikan-model-punya-tests` — ditambahkan `tests/` dengan skenario
  `odoo-yaml-test` yang menguji `auto_create_project` default `True`/`False` sesuai
  konfigurasi Type.

Tidak ada perubahan perilaku fungsional, penambahan field/fitur baru, atau penggantian
nama class/method/field/model.

## Validasi

```
#VALIDATOR name=module     target=ssi_service_revenue_recognition_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik         target=ssi_service_revenue_recognition_project series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour       target=ssi_service_revenue_recognition_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test  target=ssi_service_revenue_recognition_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=opnsynid-service modules=1 failed=0 skipped=0 status=OK
```

Peringatan `ik` (1) adalah warning "tak ada tour pasangan" untuk delta
`## Additional Post-Condition`-only (tidak menambah Flow step kasatmata) — konsisten
dengan preseden modul lain di repo ini (`ssi_service_project/docs/service_contract/05-approve.md`)
yang juga tidak berpasangan tour untuk delta jenis ini.

Closes #125