### PR TITLE
[UPD] ssi_service_revenue_recognition_operating_unit - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_revenue_recognition_operating_unit/README.rst
+++ b/ssi_service_revenue_recognition_operating_unit/README.rst
@@ -1,0 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============================================
+Service - Revenue Recognition + Operating Unit
+==============================================
+
+
+Work Instruction
+================
+
+* `Edit Service Contract <docs/service_contract/index.html>`_
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/open-synergy/opnsynid-service/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://simetri-sinergi.id/logo.png
+   :alt: PT. Simetri Sinergi Indonesia
+   :target: https://simetri-sinergi.id
+
+This module is maintained by the PT. Simetri Sinergi Indonesia.

--- a/ssi_service_revenue_recognition_operating_unit/docs/service_contract/02-edit.md
+++ b/ssi_service_revenue_recognition_operating_unit/docs/service_contract/02-edit.md
@@ -1,0 +1,15 @@
+# Edit Service Contract
+
+> **Module:** ssi_service_revenue_recognition_operating_unit\
+> **Extends:** ssi_service_revenue_recognition — model `service.contract`, aksi `02-edit`
+
+## Additional Post-Condition
+
+- When the **Create PoB** gear-icon button (`action_create_pob`, documented as an Inline
+  Action on `ssi_service_revenue_recognition`'s `02-edit.md`) creates a new Performance
+  Obligation, that Performance Obligation's **Operating Unit** is now stamped with this
+  contract's own **Operating Unit** (the field added by `ssi_service_operating_unit`,
+  `service_id.operating_unit_id`), instead of falling back to the acting user's own
+  default Operating Unit. This is not a new Flow step — clicking the button still
+  behaves exactly as documented in the base module; only the Operating Unit recorded on
+  the created Performance Obligation changes.

--- a/ssi_service_revenue_recognition_operating_unit/models/service_contract_fix_item.py
+++ b/ssi_service_revenue_recognition_operating_unit/models/service_contract_fix_item.py
@@ -6,12 +6,35 @@ from odoo import models
 
 
 class ServiceContractFixItem(models.Model):
+    """
+    Extends Service Contract Fix Item with operating unit propagation.
+
+    Stamps the Performance Obligation created by ``action_create_pob``
+    (defined in ``ssi_service_revenue_recognition``) with the same
+    ``operating_unit_id`` as the source contract (``service_id``), so
+    it does not silently fall back to
+    ``mixin.single_operating_unit``'s own default (the acting user's
+    operating unit). See ``_prepare_pob_data`` below.
+    """
+
     _name = "service.contract_fix_item"
     _inherit = [
         "service.contract_fix_item",
     ]
 
     def _prepare_pob_data(self):
+        """Add the source contract's operating unit to the PoB data.
+
+        Extends ``ssi_service_revenue_recognition``'s
+        ``_prepare_pob_data`` so the Performance Obligation created by
+        ``action_create_pob`` carries the same ``operating_unit_id``
+        as this fix item's own service contract (``service_id``),
+        instead of falling back to the acting user's default
+        operating unit.
+
+        :return: dict of values used to create the Performance
+            Obligation, with ``operating_unit_id`` added
+        """
         self.ensure_one()
         _super = super(ServiceContractFixItem, self)
         result = _super._prepare_pob_data()

--- a/ssi_service_revenue_recognition_operating_unit/tests/__init__.py
+++ b/ssi_service_revenue_recognition_operating_unit/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_service_contract_fix_item_pob_operating_unit

--- a/ssi_service_revenue_recognition_operating_unit/tests/test_data_service_contract_fix_item_pob_operating_unit.yaml
+++ b/ssi_service_revenue_recognition_operating_unit/tests/test_data_service_contract_fix_item_pob_operating_unit.yaml
@@ -1,0 +1,221 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name:
+      "PoB is stamped with the contract's own Operating Unit, not the acting user's
+      default"
+    steps:
+      - step: "Get income account"
+        action: "search"
+        model: "account.account"
+        domain: [["user_type_id.internal_group", "=", "income"]]
+        save_as: "income_account"
+        limit: 1
+
+      - step: "Get generic unit of measure"
+        action: "ref"
+        xml_id: "uom.product_uom_unit"
+        save_as: "uom"
+
+      - step: "Get default pricelist"
+        action: "ref"
+        xml_id: "product.list0"
+        save_as: "pricelist"
+
+      - step: "Get the acting user's own default operating unit (Main Operating Unit)"
+        action: "ref"
+        xml_id: "operating_unit.main_operating_unit"
+        save_as: "admin_ou"
+
+      - step: "Create partner for the contract's own operating unit"
+        action: "create"
+        model: "res.partner"
+        save_as: "contract_ou_partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB OU Contract"
+
+      - step:
+          "Create the contract's own operating unit, distinct from the acting user's
+          default"
+        action: "create"
+        model: "operating.unit"
+        save_as: "contract_ou"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Operating Unit - PoB OU Contract"
+          code: "POBOU1"
+          company_id: "REF: base.main_company"
+          partner_id: "REC: contract_ou_partner.id"
+
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Partner - PoB OU"
+          is_company: true
+
+      - step: "Create test service type"
+        action: "create"
+        model: "service.type"
+        save_as: "service_type"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Service Type - PoB OU"
+          code: "POBOU"
+
+      - step: "Create test product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lumpsum Service - PoB OU"
+          type: "service"
+          uom_id: "REC: uom.id"
+          uom_po_id: "REC: uom.id"
+
+      - step: "Create service contract with an explicit, non-default operating unit"
+        action: "create"
+        model: "service.contract"
+        save_as: "contract"
+        as_user: "base.user_admin"
+        values:
+          title: "Test Service Contract - PoB OU"
+          partner_id: "REC: partner.id"
+          type_id: "REC: service_type.id"
+          manager_id: "REF: base.user_admin"
+          salesperson_id: "REF: base.user_admin"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          date: "2026-01-01"
+          date_start: "2026-01-01"
+          date_end: "2026-12-31"
+          operating_unit_id: "REC: contract_ou.id"
+
+      - step:
+          "Assert the contract's operating unit differs from the acting user's own
+          default"
+        action: "assert"
+        target: "contract"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: contract_ou"
+          operating_unit_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REC: admin_ou.id"
+
+      - step: "Confirm contract"
+        action: "call"
+        target: "contract"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Assert confirmed (forces refresh before approve reads policy)"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve contract (opens it, auto-creates analytic account)"
+        action: "call"
+        target: "contract"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Assert contract open with its own analytic account"
+        action: "assert"
+        target: "contract"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "service.contract_fix_item_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          service_id: "REC: contract.id"
+          name: "Term 1"
+          sequence: 10
+
+      - step: "Create payment term detail"
+        action: "create"
+        model: "service.contract_fix_item_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "REC: product.name"
+          account_id: "REC: income_account.id"
+          price_unit: 500
+          quantity: 1
+          uom_quantity: 1
+          uom_id: "REC: uom.id"
+          sequence: 10
+
+      - step: "Fetch the contract fix item view row"
+        action: "search"
+        model: "service.contract_fix_item"
+        domain:
+          - ["service_id", "=", "REC: contract.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "item"
+        refresh: true
+        expect_count: 1
+
+      - step: "Create the PoB from the item, acting as the admin user"
+        action: "call"
+        target: "item"
+        method: "action_create_pob"
+        as_user: "base.user_admin"
+
+      - step: "Assert item now links to a PoB"
+        action: "assert"
+        target: "item"
+        refresh: true
+        asserts:
+          pob_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Fetch the created PoB"
+        action: "search"
+        model: "performance_obligation"
+        domain:
+          - ["source_analytic_account_id", "=", "REC: contract.analytic_account_id.id"]
+          - ["product_id", "=", "REC: product.id"]
+        save_as: "pob"
+        refresh: true
+        expect_count: 1
+
+      - step:
+          "Assert the PoB's operating unit matches the CONTRACT's, not the acting user's
+          own default"
+        action: "assert"
+        target: "pob"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: contract_ou"
+          operating_unit_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REC: admin_ou.id"

--- a/ssi_service_revenue_recognition_operating_unit/tests/test_service_contract_fix_item_pob_operating_unit.py
+++ b/ssi_service_revenue_recognition_operating_unit/tests/test_service_contract_fix_item_pob_operating_unit.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestServiceContractFixItemPobOperatingUnit(YamlTransactionCase):
+    """Covers ``service.contract_fix_item._prepare_pob_data`` OU stamp.
+
+    Verifies that a Performance Obligation created from a contract's
+    fix item (``action_create_pob``) is stamped with the source
+    contract's own Operating Unit, instead of falling back to the
+    acting user's default Operating Unit.
+    """
+
+    def test_service_contract_fix_item_pob_operating_unit(self):
+        """Run the PoB operating unit propagation scenario."""
+        self.run_yaml_scenario(
+            "test_data_service_contract_fix_item_pob_operating_unit.yaml"
+        )


### PR DESCRIPTION
## Ringkasan

Memperbaiki 5 butir temuan audit kepatuhan ERROR pada modul `ssi_service_revenue_recognition_operating_unit`:

* `modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali` — ditambahkan IK extension `docs/service_contract/02-edit.md` (Additional Post-Condition, mendokumentasikan propagasi Operating Unit ke Performance Obligation yang dibuat lewat `action_create_pob`)
* `readme-rst-ada` — ditambahkan `README.rst`
* `setiap-class-method-punya-docstring` (2 butir) — ditambahkan docstring reST pada class `ServiceContractFixItem` dan method `_prepare_pob_data`
* `modul-yang-mendefinisikan-model-punya-tests` — ditambahkan `tests/` dengan skenario `odoo-yaml-test` yang membuktikan Performance Obligation yang dibuat lewat `action_create_pob` distempel Operating Unit milik kontrak sumbernya, bukan Operating Unit default user yang menekan tombol (dijalankan sebagai `base.user_admin`, yang default OU-nya berbeda dari OU kontrak — sesuai `odoo-development` §Propagasi OU)

Tidak ada perubahan perilaku modul — hanya dokumentasi, docstring, dan test.

Keenam validator kepatuhan (`module`, `ik`, `po`, `web`, `unit-test`, `tour`) sudah dijalankan lokal dan seluruhnya `status=OK, error=0`.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)