### PR TITLE
[UPD] ssi_service_state_change_constrain - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_state_change_constrain/README.rst
+++ b/ssi_service_state_change_constrain/README.rst
@@ -7,6 +7,14 @@ Service Contract + State Change Constrain Integration
 =====================================================
 
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/index.html>`_
+* `Confirm Service Contract <docs/service_contract/index.html>`_
+* `Approve Service Contract <docs/service_contract/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_state_change_constrain/__manifest__.py
+++ b/ssi_service_state_change_constrain/__manifest__.py
@@ -13,7 +13,10 @@
     "depends": [
         "ssi_service",
         "ssi_state_change_constrain_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_state_change_constrain/docs/service_contract/01-create.md
+++ b/ssi_service_state_change_constrain/docs/service_contract/01-create.md
@@ -1,0 +1,35 @@
+# Create Service Contract
+
+> **Module:** ssi_service_state_change_constrain\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`\
+> **Inline Actions:** `action_reload_status_check_template` (Status Check Template),
+> `action_reload_status_check` (Status Check Item)
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Status Checks** tab, visible
+only to users in the **Settings / Technical** group (`base.group_system`):
+
+- **Status Check Template**: The `status.check.template` used to build the checklist
+  below. Automatically (re)selected whenever **Type** changes, based on the contract's
+  data — it is not required to pick it manually.
+- **Status Check** (list, read-only rows): One line per item defined by the selected
+  **Status Check Template**. Each line carries a **Status Ok** checkbox the user ticks
+  off as the corresponding condition is satisfied. This list is not filled by typing —
+  it is built by the **Status Check Item** button (see below).
+
+On the **Status Checks** tab, two buttons rebuild the checklist:
+
+- **Status Check Template**: Re-runs the automatic template selection (the same logic as
+  the **Type** onchange above) and writes the result to **Status Check Template**.
+- **Status Check Item**: Regenerates the **Status Check** list from the currently
+  selected **Status Check Template** — adding lines for items not yet present and
+  removing lines whose item is no longer part of the template.
+
+## Additional Post-Condition
+
+- A **State Change Constrain Template** may be auto-selected on record creation
+  (`state.change.constrain.template`, matched against the record's **Status Check
+  Template**). This field is internal — it is not shown on any form — and only
+  determines whether later state transitions are gated; see the **Modified Validation**
+  note on `04-confirm` and `05-approve`.

--- a/ssi_service_state_change_constrain/docs/service_contract/04-confirm.md
+++ b/ssi_service_state_change_constrain/docs/service_contract/04-confirm.md
@@ -1,0 +1,13 @@
+# Confirm Service Contract
+
+> **Module:** ssi_service_state_change_constrain\
+> **Extends:** ssi_service — model `service.contract`, aksi `04-confirm`
+
+## Modified Validation
+
+- Confirm will fail with an error if a **State Change Constrain Template** applies to
+  the resulting **Waiting for Approval** (`confirm`) status and the record has Status
+  Check items required by that template whose **Status Ok** checkbox (on the **Status
+  Checks** tab, see `01-create`) is not yet ticked. Whether a template applies at all is
+  configuration-driven — it is only evaluated when **State Change Constrain Template**
+  is set on the record.

--- a/ssi_service_state_change_constrain/docs/service_contract/05-approve.md
+++ b/ssi_service_state_change_constrain/docs/service_contract/05-approve.md
@@ -1,0 +1,13 @@
+# Approve Service Contract
+
+> **Module:** ssi_service_state_change_constrain\
+> **Extends:** ssi_service — model `service.contract`, aksi `05-approve`
+
+## Modified Validation
+
+- Approve will fail with an error if a **State Change Constrain Template** applies to
+  the resulting **In Progress** (`open`) status and the record has Status Check items
+  required by that template whose **Status Ok** checkbox (on the **Status Checks** tab,
+  see `01-create`) is not yet ticked. Whether a template applies at all is
+  configuration-driven — it is only evaluated when **State Change Constrain Template**
+  is set on the record.

--- a/ssi_service_state_change_constrain/models/service_contract.py
+++ b/ssi_service_state_change_constrain/models/service_contract.py
@@ -6,6 +6,15 @@ from odoo import api, models
 
 
 class ServiceContract(models.Model):
+    """Add State Change Constrain + Status Check to ``service.contract``.
+
+    :cvar _status_check_create_page: Show the "Status Checks" tab on the
+        ``service.contract`` form (restricted to ``base.group_system``).
+    :cvar _status_check_include_fields: Fields whose change re-evaluates
+        the auto-selected Status Check Template via
+        :meth:`onchange_status_check_template_id`.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",
@@ -21,6 +30,13 @@ class ServiceContract(models.Model):
 
     @api.onchange("type_id")
     def onchange_status_check_template_id(self):
+        """Re-select the Status Check Template when ``type_id`` changes.
+
+        Clears ``status_check_template_id`` first, then looks up the
+        matching ``status.check.template`` for the current record via
+        ``mixin.status_check._get_template_status_check()``. Left empty
+        when ``type_id`` is not set.
+        """
         self.status_check_template_id = False
         if self.type_id:
             self.status_check_template_id = self._get_template_status_check()

--- a/ssi_service_state_change_constrain/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_state_change_constrain/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,96 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_state_change_constrain.service_contract_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields + Inline Actions: action_reload_status_check_template,
+    // action_reload_status_check)
+    tour.register(
+        "ssi_service_state_change_constrain_service_contract_field_status_check",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md,
+            // delta of ssi_service_state_change_constrain) — the
+            // Status Checks tab added by mixin.status_check. Open it
+            // first: the tab is not the active one by default
+            // (patterns.md § notebook tabs).
+            {
+                content: "Open the Status Checks tab",
+                trigger: ".o_notebook .nav-link:contains(Status Checks)",
+            },
+
+            // Delta-only tour: assert the Status Check Template field
+            // and both reload buttons are present, then stop. It does
+            // not fill any field and does not continue to Save (E1
+            // delta-only; see odoo-development-ui-test
+            // scope-and-boundaries.md).
+            {
+                content: "Status Check Template field is displayed",
+                trigger: ".o_field_widget[name='status_check_template_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Status Check Template button is displayed",
+                trigger: "button[name='action_reload_status_check_template']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Status Check Item button is displayed",
+                trigger: "button[name='action_reload_status_check']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_state_change_constrain/tests/__init__.py
+++ b/ssi_service_state_change_constrain/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_state_change_constrain
+from . import test_ui_service_contract

--- a/ssi_service_state_change_constrain/tests/test_data_service_state_change_constrain.yaml
+++ b/ssi_service_state_change_constrain/tests/test_data_service_state_change_constrain.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service State Change Constrain - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_state_change_constrain/tests/test_service_state_change_constrain.py
+++ b/ssi_service_state_change_constrain/tests/test_service_state_change_constrain.py
@@ -9,5 +9,11 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceStateChangeConstrain(YamlTransactionCase):
+    """Test the State Change Constrain + Status Check integration."""
+
     def test_service_state_change_constrain(self):
+        """Run the create/confirm/approve YAML scenario.
+
+        :return: None.
+        """
         self.run_yaml_scenario("test_data_service_state_change_constrain.yaml")

--- a/ssi_service_state_change_constrain/tests/test_ui_service_contract.py
+++ b/ssi_service_state_change_constrain/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so a Pre-Condition fixture would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` Status Checks delta."""
+
+    def test_field_status_check(self):
+        """Run the delta tour for the ``service.contract`` create form.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_state_change_constrain_service_contract_field_" "status_check",
+            login="admin",
+        )

--- a/ssi_service_state_change_constrain/views/assets.xml
+++ b/ssi_service_state_change_constrain/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_state_change_constrain assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_state_change_constrain/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 8 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_state_change_constrain`:

* Instruksi Kerja (IK) extension `docs/service_contract/` — 01-create (Additional Fields: tab Status Checks + tombol reload), 04-confirm & 05-approve (Modified Validation), beserta tour pasangannya (delta-only, IK 01-create).
* Docstring reST pada seluruh class & method yang belum punya (model `service_contract.py` dan berkas `tests/`).
* Hapus `invalidate_cache` manual pada skenario YAML, diganti opsi `auto_refresh` milik `odoo-yaml-test`.

Tidak ada perubahan perilaku modul — assertion skenario YAML yang sudah ada tetap sama.

## Referensi

Closes #126

## Test plan

- [x] `verify-module.sh` → `status=OK`
- [x] `validate-ik.sh` → `status=OK`
- [x] `validate-tour.sh` → `status=OK`
- [x] `validate-unit-test.sh` → `status=OK` (1 peringatan cakupan onchange, di luar lingkup backlog audit sesuai issue)
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI GitHub (menyusul)