### PR TITLE
[UPD] ssi_service_quotation_work_log - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_work_log/README.rst
+++ b/ssi_service_quotation_work_log/README.rst
@@ -7,6 +7,12 @@ Service Quotation - Work Log Integration
 ========================================
 
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_quotation_work_log/__manifest__.py
+++ b/ssi_service_quotation_work_log/__manifest__.py
@@ -11,8 +11,11 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_work_log_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_quotation_work_log/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_work_log/docs/service_quotation/01-create.md
@@ -1,0 +1,22 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_work_log\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Work Log** tab:
+
+- **Work Log Analytic Account**: The analytic account used as the reference for work
+  logs recorded against this quotation. Optional.
+- **Estimation** (Work Estimation): The estimated number of work hours for this
+  quotation. Optional; used to compute the **Remaining** and **Excess** figures once
+  work logs are recorded.
+- **Work Logs**: A list of `hr.work_log` entries. Click **Add a line** to record work
+  directly on the quotation. Repeat as many times as needed.
+
+## Additional Post-Condition
+
+- The **Work Log** tab shows **Total**, **Remaining**, and **Excess** figures computed
+  automatically from the **Estimation** and the recorded **Work Logs**. These are
+  read-only and not filled directly.

--- a/ssi_service_quotation_work_log/models/service_quotation.py
+++ b/ssi_service_quotation_work_log/models/service_quotation.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """
+    Adds work log tracking to service quotations.
+    Lets users record ``hr.work_log`` entries directly on the
+    quotation, estimate the work required, and see the realized,
+    remaining, and excess work computed from those entries.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",

--- a/ssi_service_quotation_work_log/static/tests/tours/service_quotation_tour.js
+++ b/ssi_service_quotation_work_log/static/tests/tours/service_quotation_tour.js
@@ -1,0 +1,66 @@
+odoo.define("ssi_service_quotation_work_log.service_quotation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Delta-only tour (arketipe E1): this module only adds a Work
+    // Log tab to service.quotation's create form. Menu navigation
+    // and the base create/save flow are covered by
+    // ssi_service_quotation's own tour
+    // (ssi_service_quotation_service_quotation_create); this tour
+    // stops right after asserting the tab is displayed.
+    //
+    // IK: docs/service_quotation/01-create.md
+    tour.register(
+        "ssi_service_quotation_work_log_service_quotation_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; gate before touching the list.
+                },
+            },
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+                run: function () {
+                    // Assertion only. Delta stops here: this
+                    // module does not change the rest of the
+                    // create Flow.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_quotation_work_log/tests/__init__.py
+++ b/ssi_service_quotation_work_log/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_work_log
+from . import test_ui_service_quotation_work_log

--- a/ssi_service_quotation_work_log/tests/test_data_service_quotation_work_log.yaml
+++ b/ssi_service_quotation_work_log/tests/test_data_service_quotation_work_log.yaml
@@ -61,10 +61,17 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      # WAJIB: memaksa refresh cache (flush + invalidate) sebelum policy
+      # approve dibaca. Tanpa step assert ini, approve_ok terbaca dari
+      # cache yang diisi action_confirm saat approval.approval belum
+      # ada, dan approve gagal secara NONDETERMINISTIK (T-04).
+      - step: "Assert quotation still confirmed (forces cache refresh)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_work_log/tests/test_data_service_quotation_work_log.yaml
+++ b/ssi_service_quotation_work_log/tests/test_data_service_quotation_work_log.yaml
@@ -61,13 +61,17 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      # WAJIB: memaksa refresh cache (flush + invalidate) sebelum policy
-      # approve dibaca. Tanpa step assert ini, approve_ok terbaca dari
-      # cache yang diisi action_confirm saat approval.approval belum
-      # ada, dan approve gagal secara NONDETERMINISTIK (T-04).
+      # WAJIB: refresh: true memaksa _refresh() pustaka (flush + invalidate)
+      # sebelum policy approve dibaca. Tanpa refresh eksplisit di sini,
+      # approve_ok terbaca dari cache yang diisi action_confirm saat
+      # approval.approval belum ada, dan approve gagal secara
+      # NONDETERMINISTIK (T-04). Refresh disetel per-step, bukan lewat
+      # options: {auto_refresh: true} berkas, agar step ber-as_user lain
+      # di skenario ini tidak ikut memicu re-read ber-ACL (T-05).
       - step: "Assert quotation still confirmed (forces cache refresh)"
         action: "assert"
         target: "quotation"
+        refresh: true
         asserts:
           state:
             type: "value"

--- a/ssi_service_quotation_work_log/tests/test_service_quotation_work_log.py
+++ b/ssi_service_quotation_work_log/tests/test_service_quotation_work_log.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotWorkLog(YamlTransactionCase):
+    """Scenario tests for work log tracking on ``service.quotation``."""
+
     def test_service_quotation_work_log(self):
+        """Run the create-and-verify scenario for work log tracking."""
         self.run_yaml_scenario("test_data_service_quotation_work_log.yaml")

--- a/ssi_service_quotation_work_log/tests/test_ui_service_quotation_work_log.py
+++ b/ssi_service_quotation_work_log/tests/test_ui_service_quotation_work_log.py
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass; kept for consistency even though this tour needs
+# no Pre-Condition fixture beyond the admin login already provided by
+# start_tour().
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotationWorkLog(HttpSavepointCase):
+    """Tour test for the work log delta on ``service.quotation``."""
+
+    def test_create(self):
+        """Run the create tour asserting the Work Log tab is shown.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_work_log_service_quotation_create",
+            login="admin",
+        )

--- a/ssi_service_quotation_work_log/views/assets.xml
+++ b/ssi_service_quotation_work_log/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_service_quotation_work_log assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_service_quotation_work_log/static/tests/tours/service_quotation_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_quotation_work_log`:

* Menambahkan docstring pada class `ServiceQuotation`, class test, dan method test yang belum berdocstring.
* Menulis Instruksi Kerja (IK) extension (arketipe E1) untuk field Work Log yang ditambahkan modul ini pada model `service.quotation`, berikut tour UI test pasangannya (delta-only, sesuai `references/scope-and-boundaries.md` §3).
* Mengganti pemanggilan `invalidate_cache` manual di skenario YAML dengan step `assert` yang memaksa refresh cache pustaka `odoo-yaml-test` sebelum policy approve dibaca (pola T-04).

Tidak ada perubahan perilaku modul yang sudah berjalan — seluruh assertion yang ada tetap sama.

## Test plan

- [x] `verify-module.sh` → `LOLOS: 0 ERROR`
- [x] `validate-ik.sh` → `LOLOS: 0 ERROR, 0 peringatan`
- [x] `validate-unit-test.sh` → `LOLOS: 0 ERROR`
- [x] `validate-tour.sh` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI hijau

Closes open-synergy/opnsynid-service#122