### PR TITLE
[UPD] ssi_service_quotation_tnc - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_tnc/README.rst
+++ b/ssi_service_quotation_tnc/README.rst
@@ -7,6 +7,12 @@ Service Quotation - T&C Integration
 ===================================
 
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_quotation_tnc/__manifest__.py
+++ b/ssi_service_quotation_tnc/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2024 OpenSynergy Indonesia
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
+# pylint: disable=locally-disabled, manifest-required-author
 {
     "name": "Service Quotation - T&C Integration",
     "version": "14.0.1.0.0",
@@ -11,8 +12,11 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_term_condition_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_quotation_tnc/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_tnc/docs/service_quotation/01-create.md
@@ -1,0 +1,24 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_tnc\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`\
+> **Inline Actions:** `action_generate_tnc` (Generate T&C)
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Terms & Conditions** tab:
+
+- **T&C Template**: Optional. Selects a `tnc_template` record configured for the
+  `service.quotation` model. Selecting a template does not by itself fill in the
+  **Sections** / **Clauses** lists below — click **Generate T&C** (see below).
+- **Sections**: A list of T&C sections attached to the quotation. Rows may be added
+  manually with **Add a line**, or generated in bulk from **T&C Template** with
+  **Generate T&C**.
+- **Clauses**: Read-only. Automatically aggregated from the clauses of every row in
+  **Sections** — not filled directly by the user.
+
+On the **Terms & Conditions** tab, click **Generate T&C** to (re)build **Sections**
+(and, through it, **Clauses**) from the selected **T&C Template**. Running it again
+after changing **T&C Template** first discards the sections generated previously, then
+rebuilds them from the new template. If **T&C Template** is empty, **Generate T&C**
+discards any existing sections and leaves the lists empty — it does not fail.

--- a/ssi_service_quotation_tnc/models/service_quotation.py
+++ b/ssi_service_quotation_tnc/models/service_quotation.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """Attach Terms & Conditions to ``service.quotation``.
+
+    Inherits ``mixin.tnc`` and enables its auto-injected form page
+    (``_tnc_create_page = True``), giving each service quotation a
+    ``T&C Template`` field plus generated sections/clauses. See the
+    ``mixin.tnc`` docstring for the fields and the ``Generate T&C``
+    action it contributes.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",

--- a/ssi_service_quotation_tnc/static/tests/tours/service_quotation_tour.js
+++ b/ssi_service_quotation_tnc/static/tests/tours/service_quotation_tour.js
@@ -1,0 +1,87 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_quotation_tnc.service_quotation_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_quotation/01-create.md (E1 delta — Additional
+    // Fields + Inline Actions: action_generate_tnc)
+    tour.register(
+        "ssi_service_quotation_tnc_service_quotation_field_tnc",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Quotations menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                // Gate: wait for the Quotations action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_quotation/01-create.md,
+            // delta of ssi_service_quotation_tnc) — the Terms &
+            // Conditions tab added by mixin.tnc. Open it first: the
+            // tab is not the active one by default (patterns.md §
+            // notebook tabs).
+            {
+                content: "Open the Terms & Conditions tab",
+                trigger: ".o_notebook .nav-link:contains(Terms & Conditions)",
+            },
+
+            // Delta-only tour: assert the T&C Template field and the
+            // Generate T&C button are present, then stop. It does not
+            // fill any field and does not continue to Save (E1
+            // delta-only; see odoo-development-ui-test
+            // scope-and-boundaries.md).
+            {
+                content: "T&C Template field is displayed",
+                trigger: ".o_field_widget[name='tnc_template_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Generate T&C button is displayed",
+                trigger: "button[name='action_generate_tnc']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_quotation_tnc/tests/__init__.py
+++ b/ssi_service_quotation_tnc/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_tnc
+from . import test_ui_service_quotation

--- a/ssi_service_quotation_tnc/tests/test_data_service_quotation_tnc.yaml
+++ b/ssi_service_quotation_tnc/tests/test_data_service_quotation_tnc.yaml
@@ -61,10 +61,21 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      # WAJIB: refresh: true memaksa _refresh() pustaka (flush + invalidate)
+      # sebelum policy approve dibaca. Tanpa refresh eksplisit di sini,
+      # approve_ok terbaca dari cache yang diisi action_confirm saat
+      # approval.approval belum ada, dan approve gagal secara
+      # NONDETERMINISTIK (T-04). Refresh disetel per-step, bukan lewat
+      # options: {auto_refresh: true} berkas, agar step ber-as_user lain
+      # di skenario ini tidak ikut memicu re-read ber-ACL (T-05).
+      - step: "Assert quotation still confirmed (forces cache refresh)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_tnc/tests/test_service_quotation_tnc.py
+++ b/ssi_service_quotation_tnc/tests/test_service_quotation_tnc.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotTnc(YamlTransactionCase):
+    """YAML scenario test for the ``service.quotation`` T&C mixin."""
+
     def test_service_quotation_tnc(self):
+        """Run the create/confirm/approve T&C scenario."""
         self.run_yaml_scenario("test_data_service_quotation_tnc.yaml")

--- a/ssi_service_quotation_tnc/tests/test_ui_service_quotation.py
+++ b/ssi_service_quotation_tnc/tests/test_ui_service_quotation.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotation(HttpSavepointCase):
+    """Tour tests for the ``service.quotation`` T&C delta."""
+
+    def test_field_tnc(self):
+        """Run the delta tour for the ``service.quotation`` create form.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_tnc_service_quotation_field_tnc",
+            login="admin",
+        )

--- a/ssi_service_quotation_tnc/views/assets.xml
+++ b/ssi_service_quotation_tnc/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quotation_tnc assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quotation_tnc/static/tests/tours/service_quotation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_quotation_tnc`:

* Tambah Instruksi Kerja (IK) extension `docs/service_quotation/01-create.md` beserta tour pasangannya (`static/tests/tours/service_quotation_tour.js` + `tests/test_ui_service_quotation.py`) — modul ini sebelumnya tidak punya dokumentasi sama sekali.
* Lengkapi docstring class `ServiceQuotation`, class test, dan seluruh method `test_*` yang belum berdocstring.
* Hapus `invalidate_cache` manual di skenario YAML, diganti step `assert` ber-`refresh: true` (scoped per-step) sebelum `action_approve_approval` — mengikuti pola yang sudah terbukti benar di PR #136 (commit `9fc3643`) untuk mencegah `approve_ok` terbaca basi dari cache yang diisi `action_confirm` (T-04).

Tidak ada perubahan perilaku modul.

## Test plan

- [x] `verify-module.sh` → `LOLOS: 0 ERROR`
- [x] `validate-ik.sh` → `LOLOS: 0 ERROR`
- [x] `validate-tour.sh` → `LOLOS: 0 ERROR`
- [x] `validate-unit-test.sh` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI hijau (GitHub Actions)

Closes #121