### PR TITLE
[UPD] ssi_service_quotation_state_change_constrain - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_state_change_constrain/__manifest__.py
+++ b/ssi_service_quotation_state_change_constrain/__manifest__.py
@@ -13,7 +13,10 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_state_change_constrain_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_quotation_state_change_constrain/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_state_change_constrain/docs/service_quotation/01-create.md
@@ -1,0 +1,31 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_state_change_constrain\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Status Checks** tab:
+
+- **Status Check Template**: Automatically (re)selected whenever **Type** changes — the
+  first `status.check.template` configured for `service.quotation` whose condition
+  evaluates true for the record. Visible only to users in the _Technical Settings_
+  group; not user-editable through this field directly (use the **Status Check
+  Template** button described below to force a re-selection).
+- **Status Check** (list, read-only): The checklist items copied from the selected
+  **Status Check Template**. Each item shows whether it currently passes. This list is
+  what a later state change constraint (see `04-confirm` and `05-approve`) checks
+  against.
+
+The tab also carries two buttons, **Status Check Template** and **Status Check Item**
+(both visible only to the _Technical Settings_ group), that force a re-evaluation of the
+template and the checklist items respectively — normally not needed, since both are kept
+in sync automatically on create and whenever **Type** changes.
+
+## Additional Post-Condition
+
+- The new record's **Status Checks** tab is already populated: `status_check_ids` is
+  filled from the selected `status_check_template_id`, and — if a matching
+  `state.change.constrain.template` is configured — `state_change_constrain_template_id`
+  is auto-selected as well. Neither blocks Draft; they only take effect on the next
+  state change (see `04-confirm` and `05-approve`).

--- a/ssi_service_quotation_state_change_constrain/docs/service_quotation/04-confirm.md
+++ b/ssi_service_quotation_state_change_constrain/docs/service_quotation/04-confirm.md
@@ -1,0 +1,12 @@
+# Confirm Service Quotation
+
+> **Module:** ssi_service_quotation_state_change_constrain\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `04-confirm`
+
+## Modified Validation
+
+- When a **State Change Constraint** template is configured with a detail line targeting
+  state `confirm`, Confirm will fail with an error naming the first unmet item if any of
+  that line's required **Status Check** items (see `01-create`) is not yet passed (or
+  bypassed). Which template applies, and which status check items it requires for
+  `confirm`, is configuration-driven — not fixed by this module.

--- a/ssi_service_quotation_state_change_constrain/docs/service_quotation/05-approve.md
+++ b/ssi_service_quotation_state_change_constrain/docs/service_quotation/05-approve.md
@@ -1,0 +1,12 @@
+# Approve Service Quotation
+
+> **Module:** ssi_service_quotation_state_change_constrain\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `05-approve`
+
+## Modified Validation
+
+- When a **State Change Constraint** template is configured with a detail line targeting
+  state `open`, Approve will fail with an error naming the first unmet item if any of
+  that line's required **Status Check** items (see `01-create`) is not yet passed (or
+  bypassed). Which template applies, and which status check items it requires for
+  `open`, is configuration-driven — not fixed by this module.

--- a/ssi_service_quotation_state_change_constrain/models/service_quotation.py
+++ b/ssi_service_quotation_state_change_constrain/models/service_quotation.py
@@ -6,6 +6,16 @@ from odoo import api, models
 
 
 class ServiceQuotation(models.Model):
+    """
+    Adds status check and state change constraint to service quotations.
+
+    Extends ``service.quotation`` with a **Status Checks** tab
+    (``mixin.status_check``) and a state change gate
+    (``mixin.state_change_constrain``) that, when a matching
+    ``state.change.constrain.template`` is configured, blocks a state
+    transition until every required status check item is satisfied.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
@@ -17,6 +27,13 @@ class ServiceQuotation(models.Model):
 
     @api.onchange("type_id")
     def onchange_status_check_template_id(self):
+        """Re-select the status check template when Type changes.
+
+        Clears ``status_check_template_id`` first, then re-resolves it
+        via ``_get_template_status_check`` (``mixin.status_check``) so
+        the **Status Checks** tab always matches the record's current
+        **Type**.
+        """
         self.status_check_template_id = False
         if self.type_id:
             self.status_check_template_id = self._get_template_status_check()

--- a/ssi_service_quotation_state_change_constrain/static/tests/tours/service_quotation_state_change_constrain_tour.js
+++ b/ssi_service_quotation_state_change_constrain/static/tests/tours/service_quotation_state_change_constrain_tour.js
@@ -1,0 +1,81 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_service_quotation_state_change_constrain." +
+        "service_quotation_state_change_constrain_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/service_quotation/01-create.md (E1 delta -- Additional
+        // Fields). Navigation (open menu -> New) is taken from the base IK
+        // ssi_service_quotation/docs/service_quotation/01-create.md Flow
+        // steps 1-2 -- see skill odoo-development-ui-test,
+        // scope-and-boundaries.md §1 ("Backing dua file: tour extension =
+        // base IK ∪ delta IK"). The delta assertion comes from this
+        // module's own IK: the Status Checks tab is present on the create
+        // form. The tour stops there; it does not fill, save, or confirm
+        // (E1 delta-only).
+        tour.register(
+            "ssi_service_quotation_state_change_constrain_" +
+                "service_quotation_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [
+                // ── Base Flow 1 — Open the Service > Quotations menu.
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Service app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+                },
+                {
+                    content: "Open the Quotations menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+                },
+                {
+                    content: "Quotations list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; gate before touching the list.
+                    },
+                },
+
+                // ── Base Flow 2 — Click the New button. (14.0: "Create")
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // ── Delta assertion — the Status Checks tab added by this
+                // module is present on the create form. The tour stops
+                // here (E1 delta-only).
+                {
+                    content: "The Status Checks tab is present",
+                    trigger:
+                        ".o_form_view.o_form_editable .o_notebook " +
+                        ".nav-link:contains('Status Checks')",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_service_quotation_state_change_constrain/tests/__init__.py
+++ b/ssi_service_quotation_state_change_constrain/tests/__init__.py
@@ -2,4 +2,7 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import test_service_quotation_state_change_constrain
+from . import (
+    test_service_quotation_state_change_constrain,
+    test_ui_service_quotation_state_change_constrain,
+)

--- a/ssi_service_quotation_state_change_constrain/tests/test_data_service_quotation_state_change_constrain.yaml
+++ b/ssi_service_quotation_state_change_constrain/tests/test_data_service_quotation_state_change_constrain.yaml
@@ -61,10 +61,22 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      # WAJIB: refresh: true memaksa _refresh() pustaka (flush +
+      # invalidate) sebelum policy approve dibaca. Tanpa refresh
+      # eksplisit di sini, approve_ok terbaca dari cache yang diisi
+      # action_confirm saat approval.approval belum ada, dan approve
+      # gagal secara NONDETERMINISTIK (T-04). Refresh disetel
+      # per-step, bukan lewat options: {auto_refresh: true} berkas,
+      # agar step ber-as_user lain di skenario ini tidak ikut memicu
+      # re-read ber-ACL (T-05).
+      - step: "Assert quotation still confirmed (forces cache refresh)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_state_change_constrain/tests/test_service_quotation_state_change_constrain.py
+++ b/ssi_service_quotation_state_change_constrain/tests/test_service_quotation_state_change_constrain.py
@@ -9,7 +9,15 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotStateChangeConstrain(YamlTransactionCase):
+    """Test the status check / state change constrain integration.
+
+    Covers ``service.quotation`` with ``mixin.state_change_constrain``
+    and ``mixin.status_check`` installed: create, confirm, and approve
+    still work when no state change constraint template is configured.
+    """
+
     def test_service_quotation_state_change_constrain(self):
+        """Run the create-confirm-approve scenario YAML."""
         self.run_yaml_scenario(
             "test_data_service_quotation_state_change_constrain.yaml"
         )

--- a/ssi_service_quotation_state_change_constrain/tests/test_ui_service_quotation_state_change_constrain.py
+++ b/ssi_service_quotation_state_change_constrain/tests/test_ui_service_quotation_state_change_constrain.py
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass (see odoo-development-ui-test skill,
+# structure-and-runner.md, §Base class).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotationStateChangeConstrain(HttpSavepointCase):
+    """Tour test for the create-time Status Checks tab."""
+
+    def test_create(self):
+        """Run the create tour for ``service.quotation``.
+
+        IK: docs/service_quotation/01-create.md (E1 delta -- Additional
+        Fields)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_state_change_constrain_service_quotation_create",
+            login="admin",
+        )

--- a/ssi_service_quotation_state_change_constrain/views/assets.xml
+++ b/ssi_service_quotation_state_change_constrain/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quotation_state_change_constrain assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quotation_state_change_constrain/static/tests/tours/service_quotation_state_change_constrain_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 8 butir temuan audit kepatuhan ERROR pada modul
`ssi_service_quotation_state_change_constrain` (sapuan `audit-sweep.sh 14.0 --repo opnsynid-service`,
sidik jari `2bed59d3423c411c`, 14 Agustus 2026):

* `modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali` — Instruksi Kerja (IK)
  extension ditulis di `docs/service_quotation/` (`01-create.md`, `04-confirm.md`,
  `05-approve.md`), beserta tour pasangan `01-create.md` (E1 delta-only).
* `setiap-class-method-punya-docstring` — docstring class & method model yang belum ada
  ditambahkan.
* `setiap-class-method-test-punya-docstring` — docstring class test, method test YAML,
  dan method tour ditambahkan.
* `tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh` — step `invalidate_cache`
  manual di skenario YAML diganti step `assert` ber-`refresh: true`, mengikuti pola yang
  sudah dipakai di PR #136 (issue #122, commit 9fc3643) untuk mencegah `action_approve_approval`
  membaca `approve_ok` basi.

Tidak ada perubahan perilaku modul — hanya kepatuhan dokumentasi/test.

## Validator

Keenam validator kepatuhan lolos `status=OK` untuk modul ini:

```
#VALIDATOR name=module    target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_quotation_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Kedua peringatan (`ik`: README.rst tak punya bagian Work Instruction; `unit-test`: cakupan
`action: form` untuk onchange) berada di luar lingkup issue ini (lihat `## Ruang Lingkup`
di issue) dan tidak diminta diperbaiki.

Closes #120