### PR TITLE
[UPD] ssi_service_risk_analysis - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_risk_analysis/README.rst
+++ b/ssi_service_risk_analysis/README.rst
@@ -7,6 +7,12 @@ Contract + Risk Analysis Integration
 ====================================
 
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_risk_analysis/__manifest__.py
+++ b/ssi_service_risk_analysis/__manifest__.py
@@ -12,9 +12,10 @@
     "depends": [
         "ssi_service",
         "ssi_risk_analysis",
+        "web_tour",
     ],
     "data": [
-        # "views/crm_lead_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_service_risk_analysis/docs/service_contract/01-create.md
+++ b/ssi_service_risk_analysis/docs/service_contract/01-create.md
@@ -1,0 +1,17 @@
+# Create Service Contract
+
+> **Module:** ssi_service_risk_analysis\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Risk Analysis** tab:
+
+- **Risk Analysis**: Optional. Selects a `risk_analysis` record for the contract's
+  **Partner**. The selection list is domain-filtered to non-cancelled risk analyses
+  whose partner matches the contract's **Partner** (commercial partner).
+- **Risk Analysis State**: Read-only. Shows the status of the selected **Risk
+  Analysis**; empty until one is selected.
+- **Risk Analysis Result**: Read-only. Automatically filled from the selected **Risk
+  Analysis** once that risk analysis reaches **Done**; empty otherwise. Not filled
+  directly by the user.

--- a/ssi_service_risk_analysis/models/service_contract.py
+++ b/ssi_service_risk_analysis/models/service_contract.py
@@ -6,6 +6,18 @@ from odoo import models
 
 
 class ServiceContract(models.Model):
+    """Attach a risk analysis link to ``service.contract``.
+
+    Inherits ``mixin.risk_analysis`` and enables its auto-injected form
+    page (``_risk_analysis_create_page = True``), giving each service
+    contract a **Risk Analysis** tab where ``risk_analysis_id`` can be
+    selected. ``_risk_analysis_partner_field_name`` points the mixin at
+    ``partner_id`` so the field's selection domain
+    (``allowed_risk_analysis_ids``) is restricted to risk analyses of
+    the contract's own partner. See the ``mixin.risk_analysis``
+    docstring for the fields it contributes.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",

--- a/ssi_service_risk_analysis/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_risk_analysis/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,78 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_risk_analysis.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields: Risk Analysis tab)
+    tour.register(
+        "ssi_service_risk_analysis_service_contract_field_risk_analysis",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md,
+            // delta of ssi_service_risk_analysis) — the Risk Analysis
+            // tab added by mixin.risk_analysis. Open it first: the tab
+            // is not the active one by default (patterns.md § notebook
+            // tabs).
+            {
+                content: "Open the Risk Analysis tab",
+                trigger: ".o_notebook .nav-link:contains(Risk Analysis)",
+            },
+
+            // Delta-only tour: assert the Risk Analysis field is
+            // present, then stop. It does not fill any field and does
+            // not continue to Save (E1 delta-only; see
+            // odoo-development-ui-test scope-and-boundaries.md).
+            {
+                content: "Risk Analysis field is displayed",
+                trigger: ".o_field_widget[name='risk_analysis_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_risk_analysis/tests/__init__.py
+++ b/ssi_service_risk_analysis/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_risk_analysis
+from . import test_ui_service_contract

--- a/ssi_service_risk_analysis/tests/test_data_service_risk_analysis.yaml
+++ b/ssi_service_risk_analysis/tests/test_data_service_risk_analysis.yaml
@@ -61,10 +61,21 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      # WAJIB: refresh: true memaksa _refresh() pustaka (flush + invalidate)
+      # sebelum policy approve dibaca. Tanpa refresh eksplisit di sini,
+      # approve_ok terbaca dari cache yang diisi action_confirm saat
+      # approval.approval belum ada, dan approve gagal secara
+      # NONDETERMINISTIK (T-04). Refresh disetel per-step, bukan lewat
+      # options: {auto_refresh: true} berkas, agar step ber-as_user lain
+      # di skenario ini tidak ikut memicu re-read ber-ACL (T-05).
+      - step: "Assert contract still confirmed (forces cache refresh)"
+        action: "assert"
         target: "contract"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_risk_analysis/tests/test_service_risk_analysis.py
+++ b/ssi_service_risk_analysis/tests/test_service_risk_analysis.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceRiskAnalysis(YamlTransactionCase):
+    """YAML scenario test for the ``service.contract`` risk analysis link."""
+
     def test_service_risk_analysis(self):
+        """Run the create/confirm/approve risk analysis scenario."""
         self.run_yaml_scenario("test_data_service_risk_analysis.yaml")

--- a/ssi_service_risk_analysis/tests/test_ui_service_contract.py
+++ b/ssi_service_risk_analysis/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` risk analysis delta."""
+
+    def test_field_risk_analysis(self):
+        """Run the delta tour for the ``service.contract`` create form.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_risk_analysis_service_contract_field_risk_analysis",
+            login="admin",
+        )

--- a/ssi_service_risk_analysis/views/assets.xml
+++ b/ssi_service_risk_analysis/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_risk_analysis assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_risk_analysis/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Perbaikan temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada
modul `ssi_service_risk_analysis`:

- Menambahkan direktori `docs/` berisi IK delta (arketipe E1) untuk field **Risk
  Analysis** yang ditambahkan modul ini pada `service.contract`, beserta tour
  pasangannya (`docs/service_contract/01-create.md` + `service_contract_tour.js`).
- Menambahkan docstring pada class `ServiceContract` dan pada class/method test YAML
  yang sebelumnya belum punya docstring.
- Menghapus pemanggilan `invalidate_cache` manual di skenario YAML unit test, diganti
  step `assert` ber-`refresh: true` sebelum `action_approve_approval` (pola dari
  commit 9fc3643 / PR #136) agar `approve_ok` tidak terbaca basi dari cache yang diisi
  `action_confirm`.

Tidak ada perubahan perilaku modul — perubahan murni dokumentasi, test, dan docstring.

## Kriteria Penerimaan

- [x] `validate-ik.sh` dan `validate-tour.sh` keduanya `status=OK`
- [x] `verify-module.sh` tidak lagi melaporkan `setiap-class-method-punya-docstring`
- [x] `validate-unit-test.sh` tidak lagi melaporkan
      `setiap-class-method-test-punya-docstring`
- [x] Tidak ada lagi `invalidate_cache` di berkas YAML modul ini; skenario tetap
      lolos (CI)
- [x] `pre-commit-gate.sh` mencetak `GATE OK` untuk modul ini

Closes #117