### PR TITLE
[UPD] ssi_service_quotation_risk_analysis - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_risk_analysis/README.rst
+++ b/ssi_service_quotation_risk_analysis/README.rst
@@ -7,6 +7,13 @@ Quotation + Risk Analysis Integration
 =====================================
 
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/01-create.html>`_
+* `Mark Service Quotation as Win <docs/service_quotation/07-win.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_quotation_risk_analysis/__manifest__.py
+++ b/ssi_service_quotation_risk_analysis/__manifest__.py
@@ -13,7 +13,10 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_service_risk_analysis",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_quotation_risk_analysis/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_risk_analysis/docs/service_quotation/01-create.md
@@ -1,0 +1,17 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_risk_analysis\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Risk Analysis** tab:
+
+- **Risk Analysis**: Optional. Selects a `risk_analysis` record for the quotation's
+  **Partner**. The selection list is domain-filtered to non-cancelled risk analyses
+  whose partner matches the quotation's **Partner** (commercial partner).
+- **Risk Analysis State**: Read-only. Shows the status of the selected **Risk
+  Analysis**; empty until one is selected.
+- **Risk Analysis Result**: Read-only. Automatically filled from the selected **Risk
+  Analysis** once that risk analysis reaches **Done**; empty otherwise. Not filled
+  directly by the user.

--- a/ssi_service_quotation_risk_analysis/docs/service_quotation/07-win.md
+++ b/ssi_service_quotation_risk_analysis/docs/service_quotation/07-win.md
@@ -1,0 +1,11 @@
+# Mark Service Quotation as Win
+
+> **Module:** ssi_service_quotation_risk_analysis\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `07-win`
+
+## Additional Post-Condition
+
+- The **Service Contract** automatically created when the quotation is marked **Win**
+  (see the base `07-win.md` Post-Condition) also carries over the quotation's selected
+  **Risk Analysis**, so the new contract's own Risk Analysis tab is pre-filled with the
+  same `risk_analysis` record.

--- a/ssi_service_quotation_risk_analysis/models/service_quotation.py
+++ b/ssi_service_quotation_risk_analysis/models/service_quotation.py
@@ -6,6 +6,18 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """Attach a risk analysis link to ``service.quotation``.
+
+    Inherits ``mixin.risk_analysis`` and enables its auto-injected form
+    page (``_risk_analysis_create_page = True``), giving each service
+    quotation a **Risk Analysis** tab where ``risk_analysis_id`` can be
+    selected. ``_risk_analysis_partner_field_name`` points the mixin at
+    ``partner_id`` so the field's selection domain
+    (``allowed_risk_analysis_ids``) is restricted to risk analyses of
+    the quotation's own partner. See the ``mixin.risk_analysis``
+    docstring for the fields it contributes.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
@@ -15,6 +27,14 @@ class ServiceQuotation(models.Model):
     _risk_analysis_partner_field_name = "partner_id"
 
     def _prepare_contract_data(self):
+        """Carry the selected risk analysis into the generated contract.
+
+        Extends the base ``_prepare_contract_data`` values with
+        ``risk_analysis_id`` so the ``service.contract`` created when
+        this quotation is won keeps the same risk analysis link.
+
+        :return: dict of ``service.contract`` values
+        """
         self.ensure_one()
         _super = super(ServiceQuotation, self)
         result = _super._prepare_contract_data()

--- a/ssi_service_quotation_risk_analysis/static/tests/tours/service_quotation_tour.js
+++ b/ssi_service_quotation_risk_analysis/static/tests/tours/service_quotation_tour.js
@@ -1,0 +1,81 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_quotation_risk_analysis.service_quotation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_quotation/01-create.md (E1 delta — Additional
+    // Fields: Risk Analysis tab)
+    tour.register(
+        "ssi_service_quotation_risk_analysis_service_quotation_field_risk_analysis",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Quotations menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                // Gate: wait for the Quotations action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_quotation/01-create.md,
+            // delta of ssi_service_quotation_risk_analysis) — the Risk
+            // Analysis tab added by mixin.risk_analysis. Open it first:
+            // the tab is not the active one by default (patterns.md §
+            // notebook tabs).
+            {
+                content: "Open the Risk Analysis tab",
+                trigger: ".o_notebook .nav-link:contains(Risk Analysis)",
+            },
+
+            // Delta-only tour: assert the Risk Analysis field is
+            // present, then stop. It does not fill any field and does
+            // not continue to Save (E1 delta-only; see
+            // odoo-development-ui-test scope-and-boundaries.md).
+            {
+                content: "Risk Analysis field is displayed",
+                trigger: ".o_field_widget[name='risk_analysis_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_quotation_risk_analysis/tests/__init__.py
+++ b/ssi_service_quotation_risk_analysis/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_risk_analysis
+from . import test_ui_service_quotation

--- a/ssi_service_quotation_risk_analysis/tests/test_data_service_quotation_risk_analysis.yaml
+++ b/ssi_service_quotation_risk_analysis/tests/test_data_service_quotation_risk_analysis.yaml
@@ -61,10 +61,21 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      # WAJIB: refresh: true memaksa _refresh() pustaka (flush + invalidate)
+      # sebelum policy approve dibaca. Tanpa refresh eksplisit di sini,
+      # approve_ok terbaca dari cache yang diisi action_confirm saat
+      # approval.approval belum ada, dan approve gagal secara
+      # NONDETERMINISTIK (T-04). Refresh disetel per-step, bukan lewat
+      # options: {auto_refresh: true} berkas, agar step ber-as_user lain
+      # di skenario ini tidak ikut memicu re-read ber-ACL (T-05).
+      - step: "Assert quotation still confirmed (forces cache refresh)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_risk_analysis/tests/test_service_quotation_risk_analysis.py
+++ b/ssi_service_quotation_risk_analysis/tests/test_service_quotation_risk_analysis.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotRiskAnalysis(YamlTransactionCase):
+    """YAML scenario test for the ``service.quotation`` risk analysis link."""
+
     def test_service_quotation_risk_analysis(self):
+        """Run the create/confirm/approve risk analysis scenario."""
         self.run_yaml_scenario("test_data_service_quotation_risk_analysis.yaml")

--- a/ssi_service_quotation_risk_analysis/tests/test_ui_service_quotation.py
+++ b/ssi_service_quotation_risk_analysis/tests/test_ui_service_quotation.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotation(HttpSavepointCase):
+    """Tour tests for the ``service.quotation`` risk analysis delta."""
+
+    def test_field_risk_analysis(self):
+        """Run the delta tour for the ``service.quotation`` create form.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_risk_analysis_service_quotation_field_risk_analysis",
+            login="admin",
+        )

--- a/ssi_service_quotation_risk_analysis/views/assets.xml
+++ b/ssi_service_quotation_risk_analysis/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quotation_risk_analysis assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quotation_risk_analysis/static/tests/tours/service_quotation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 8 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_quotation_risk_analysis`:

* Docstring pada setiap class & method model (`ServiceQuotation`, `_prepare_contract_data`) dan pada berkas test (unit test + tour), termasuk `setUpClass`/method `test_*`.
* `invalidate_cache` manual di skenario YAML diganti opsi auto-refresh cache (`refresh: true` per-step) milik `odoo-yaml-test`, mengikuti pola yang sama dengan perbaikan issue #122 (PR #136, commit 9fc3643) — mencegah `action_approve_approval` membaca `approve_ok` basi.
* Modul sebelumnya tidak punya direktori `docs/` sama sekali — ditambahkan IK extension:
  * `docs/service_quotation/01-create.md` — field tambahan (tab **Risk Analysis**) pada create form `service.quotation`.
  * `docs/service_quotation/07-win.md` — perilaku tambahan: carry-over `risk_analysis_id` ke `service.contract` yang dibuat otomatis saat quotation di-*Win*-kan.
  * Tour pasangan `01-create.md` (`static/tests/tours/service_quotation_tour.js` + `tests/test_ui_service_quotation.py`), delta-only (assert field tampil, tidak lanjut confirm/approve).
  * Entri `Work Instruction` ditambahkan ke `README.rst`.

Tidak ada perubahan perilaku fungsional modul — hanya dokumentasi, docstring, dan penggantian mekanisme cache-refresh test.

## Test plan

- [x] `verify-module.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `validate-ik.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `validate-tour.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `validate-unit-test.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `pre-commit-gate.sh` → `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`
- [ ] CI GitHub hijau (unit test skenario YAML tetap lolos apa adanya)

Closes #118