### PR TITLE
[UPD] ssi_service_quotation_lead - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_lead/README.rst
+++ b/ssi_service_quotation_lead/README.rst
@@ -19,6 +19,11 @@ To install this module, you need to:
 5.  Search For *Service Quotation - Lead Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/01-create.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_service_quotation_lead/__manifest__.py
+++ b/ssi_service_quotation_lead/__manifest__.py
@@ -12,7 +12,12 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_lead",
+        "web_tour",
     ],
-    "data": ["views/service_quotation_views.xml", "views/crm_lead_views.xml"],
+    "data": [
+        "views/service_quotation_views.xml",
+        "views/crm_lead_views.xml",
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_quotation_lead/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_lead/docs/service_quotation/01-create.md
@@ -1,0 +1,12 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_lead\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+- **# Lead**: Optional. The `crm.lead` this quotation originates from. Editable only
+  while the quotation is in **Draft**; becomes read-only once the quotation leaves
+  Draft. Choices are domain-filtered to leads whose partner shares the same commercial
+  partner as the quotation's **Partner** — the field stays empty (no choices) until
+  **Partner** is set.

--- a/ssi_service_quotation_lead/models/crm_lead.py
+++ b/ssi_service_quotation_lead/models/crm_lead.py
@@ -6,6 +6,13 @@ from odoo import api, fields, models
 
 
 class CrmLead(models.Model):
+    """Extend ``crm.lead`` with service quotation linkage.
+
+    Adds ``quotation_ids`` so a CRM lead can list every
+    ``service.quotation`` created for it, plus a computed estimated
+    revenue rolled up from the quotations that are still open.
+    """
+
     _name = "crm.lead"
     _inherit = [
         "crm.lead",
@@ -31,6 +38,10 @@ class CrmLead(models.Model):
 
     @api.model
     def _default_service_currency_id(self):
+        """Return the default currency for ``service_currency_id``.
+
+        :return: the current company's currency (``res.currency``).
+        """
         return self.env.user.company_id.currency_id
 
     @api.depends(
@@ -39,6 +50,12 @@ class CrmLead(models.Model):
         "quotation_ids.state",
     )
     def _compute_service_estimated_revenue(self):
+        """Sum untaxed amounts of the lead's still-open quotations.
+
+        Quotations in state ``cancel`` or ``lost`` are excluded, and
+        only quotations sharing ``service_currency_id`` are summed —
+        amounts in another currency are not converted.
+        """
         for record in self:
             result = 0.0
             for quotation in record.quotation_ids.filtered(

--- a/ssi_service_quotation_lead/models/service_quotation.py
+++ b/ssi_service_quotation_lead/models/service_quotation.py
@@ -6,6 +6,13 @@ from odoo import api, fields, models
 
 
 class ServiceQuotation(models.Model):
+    """Extend ``service.quotation`` with a link back to a CRM lead.
+
+    Adds ``lead_id`` so a quotation can originate from a ``crm.lead``,
+    plus ``allowed_quotation_ids`` used to restrict the leads offered
+    when picking that link.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
@@ -32,6 +39,12 @@ class ServiceQuotation(models.Model):
         "partner_id",
     )
     def _compute_allowed_quotation_ids(self):
+        """Restrict ``lead_id`` choices to leads of the same partner.
+
+        Searches ``crm.lead`` for records whose partner shares the
+        same commercial partner as this quotation's ``partner_id``.
+        Empty when ``partner_id`` is not set.
+        """
         for record in self:
             result = []
             if record.partner_id:

--- a/ssi_service_quotation_lead/static/tests/tours/service_quotation_lead_tour.js
+++ b/ssi_service_quotation_lead/static/tests/tours/service_quotation_lead_tour.js
@@ -1,0 +1,68 @@
+odoo.define("ssi_service_quotation_lead.service_quotation_lead_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Delta tour for E1 (Additional Fields) — reuses the base "open menu"
+    // Flow step 1 from ssi_service_quotation, since the delta IK does not
+    // repeat it. See docs/service_quotation/01-create.md (delta) plus
+    // ssi_service_quotation/docs/service_quotation/01-create.md (base).
+    function openQuotationsMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; gate before touching the list.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/service_quotation/01-create.md (delta — Additional Fields)
+    tour.register(
+        "ssi_service_quotation_lead_service_quotation_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openQuotationsMenuSteps(), [
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "The additional # Lead field is present",
+                trigger: ".o_field_many2one[name='lead_id']",
+                run: function () {
+                    // Assertion only — delta tour stops here, it does not
+                    // fill in Partner/save/confirm (that is the base
+                    // module's own 01-create tour).
+                },
+            },
+        ])
+    );
+});

--- a/ssi_service_quotation_lead/tests/__init__.py
+++ b/ssi_service_quotation_lead/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_lead
+from . import test_ui_service_quotation

--- a/ssi_service_quotation_lead/tests/test_data_service_quotation_lead.yaml
+++ b/ssi_service_quotation_lead/tests/test_data_service_quotation_lead.yaml
@@ -61,10 +61,14 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      - step: "Refresh cache after confirm"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_lead/tests/test_service_quotation_lead.py
+++ b/ssi_service_quotation_lead/tests/test_service_quotation_lead.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotLead(YamlTransactionCase):
+    """Test the ``crm.lead`` / ``service.quotation`` link scenarios."""
+
     def test_service_quotation_lead(self):
+        """Run the create, confirm and approve scenario."""
         self.run_yaml_scenario("test_data_service_quotation_lead.yaml")

--- a/ssi_service_quotation_lead/tests/test_ui_service_quotation.py
+++ b/ssi_service_quotation_lead/tests/test_ui_service_quotation.py
@@ -1,0 +1,36 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so Pre-Condition fixtures below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotationLead(HttpSavepointCase):
+    """Tour test for the ``lead_id`` delta on ``service.quotation``."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up nothing extra: the delta tour only opens a new form.
+
+        No partner/type/quotation fixture is required because the
+        delta tour under test stops at asserting the ``# Lead`` field
+        is present on the create form — it does not fill in or save
+        the record (that flow belongs to the base module's own
+        01-create tour).
+        """
+        super().setUpClass()
+
+    def test_create(self):
+        """Run the delta create tour asserting the ``# Lead`` field.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_lead_service_quotation_create",
+            login="admin",
+        )

--- a/ssi_service_quotation_lead/views/assets.xml
+++ b/ssi_service_quotation_lead/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_service_quotation_lead assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_service_quotation_lead/static/tests/tours/service_quotation_lead_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 11 butir temuan ERROR sapuan kepatuhan pada modul `ssi_service_quotation_lead`:

* Docstring reST (Inggris, ≤79 karakter) untuk setiap class & method yang belum punya —
  `models/crm_lead.py`, `models/service_quotation.py`, `tests/test_service_quotation_lead.py`.
* Instruksi Kerja delta `docs/service_quotation/01-create.md` (field tambahan **# Lead**
  pada `service.quotation`) beserta tour pasangannya
  (`static/tests/tours/service_quotation_lead_tour.js` +
  `tests/test_ui_service_quotation.py`), sesuai arketipe E1 (delta-only: buka menu → New →
  assert field muncul → berhenti).
* Menghapus step `invalidate_cache` manual di `tests/test_data_service_quotation_lead.yaml`,
  diganti step `action: assert` ber-`refresh: true` di antara confirm & approve (pola T-04 —
  mencegah `action_approve_approval` membaca `approve_ok` basi dari cache yang diisi
  `action_confirm`).

Tidak ada perubahan perilaku modul — assertion yang sudah ada tetap sama.

## Kriteria Penerimaan

- [x] `validate-ik.sh` dan `validate-tour.sh` keduanya `status=OK`
- [x] `verify-module.sh` tidak lagi melaporkan `setiap-class-method-punya-docstring`
- [x] `validate-unit-test.sh` tidak lagi melaporkan `setiap-class-method-test-punya-docstring`
- [x] Tidak ada lagi `invalidate_cache` di berkas YAML modul ini
- [x] `pre-commit-gate.sh` → `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`

Closes open-synergy/opnsynid-service#114