### PR TITLE
[UPD] ssi_service_contract_work_log - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_contract_work_log/README.rst
+++ b/ssi_service_contract_work_log/README.rst
@@ -7,6 +7,11 @@ Service Contract - Work Log Integration
 =======================================
 
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/01-create.html>`_
+
 Installation
 ============
 

--- a/ssi_service_contract_work_log/__manifest__.py
+++ b/ssi_service_contract_work_log/__manifest__.py
@@ -11,8 +11,11 @@
     "depends": [
         "ssi_service",
         "ssi_work_log_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_contract_work_log/docs/service_contract/01-create.md
+++ b/ssi_service_contract_work_log/docs/service_contract/01-create.md
@@ -1,0 +1,17 @@
+# Create Service Contract
+
+> **Module:** ssi_service_contract_work_log\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Work Log** tab:
+
+- **Estimation**: Optional. The estimated amount of work planned for the contract.
+- **Analytic Account** (labeled **Work Log Analytic Account**): Optional. The analytic
+  account new work log entries for this contract default to.
+- **Total**, **Remaining**, **Excess**: Read-only. Automatically computed from the
+  contract's linked work logs (`hr.work_log`) and the **Estimation** above; not filled
+  directly.
+- **Work Logs**: Read-only summary list of `hr.work_log` records linked to this
+  contract. Work logs are created from their own menu, not from this tab.

--- a/ssi_service_contract_work_log/models/service_contract.py
+++ b/ssi_service_contract_work_log/models/service_contract.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class ServiceContract(models.Model):
+    """Add work log tracking to ``service.contract``.
+
+    Activates ``mixin.work_object`` on the service contract so hours
+    worked against the contract can be logged (``hr.work_log``) and
+    reviewed on a dedicated Work Log tab, alongside the contract's own
+    lifecycle managed by ``ssi_service``.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",

--- a/ssi_service_contract_work_log/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_contract_work_log/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,62 @@
+odoo.define("ssi_service_contract_work_log.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (delta — extends ssi_service)
+    //
+    // Delta-only tour (arketipe E1): navigation is the same "open Service >
+    // Contracts, click Create" flow already covered by ssi_service's own
+    // create tour. The only thing this tour proves is that installing this
+    // module adds a visible Work Log tab to the form — it does not save the
+    // record or continue into confirm/approve, which stay ssi_service's
+    // responsibility.
+    tour.register(
+        "ssi_service_contract_work_log_service_contract_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; gate before touching the list.
+                },
+            },
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Additional Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+                run: function () {
+                    // Assertion only — the delta stops here. Saving and
+                    // moving the contract through confirm/approve is
+                    // ssi_service's own create tour, not this module's.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_contract_work_log/tests/__init__.py
+++ b/ssi_service_contract_work_log/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_contract_work_log
+from . import test_ui_service_contract

--- a/ssi_service_contract_work_log/tests/test_data_service_contract_work_log.yaml
+++ b/ssi_service_contract_work_log/tests/test_data_service_contract_work_log.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Contract Work Log - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_contract_work_log/tests/test_service_contract_work_log.py
+++ b/ssi_service_contract_work_log/tests/test_service_contract_work_log.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceContractWorkLog(YamlTransactionCase):
+    """Cover the work log integration added to ``service.contract``.
+
+    Exercises the contract lifecycle (draft -> confirm -> open) that
+    ``ssi_service_contract_work_log`` relies on to expose the Work Log
+    tab, without asserting on ``hr.work_log`` records themselves.
+    """
+
     def test_service_contract_work_log(self):
+        """Run the create-confirm-approve scenario for the contract."""
         self.run_yaml_scenario("test_data_service_contract_work_log.yaml")

--- a/ssi_service_contract_work_log/tests/test_ui_service_contract.py
+++ b/ssi_service_contract_work_log/tests/test_ui_service_contract.py
@@ -1,0 +1,34 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so Pre-Condition fixtures below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour test for the work log delta on ``service.contract``."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the class; no extra fixtures are needed.
+
+        The tour only opens a blank create form and checks that the
+        Work Log tab this module adds is visible — it never saves the
+        record, so no partner/type/contract fixtures are required.
+        """
+        super().setUpClass()
+
+    def test_create(self):
+        """Run the create tour asserting the Work Log tab appears.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_contract_work_log_service_contract_create",
+            login="admin",
+        )

--- a/ssi_service_contract_work_log/views/assets.xml
+++ b/ssi_service_contract_work_log/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_service_contract_work_log assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_service_contract_work_log/static/tests/tours/service_contract_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_contract_work_log`:

- Tambah docstring pada class `ServiceContract` dan pada class/method test (`setiap-class-method-punya-docstring`, `setiap-class-method-test-punya-docstring`)
- Hapus `invalidate_cache` manual di skenario YAML, diganti opsi `auto_refresh` milik pustaka `odoo-yaml-test` (`tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh`)
- Tambah Instruksi Kerja extension `docs/service_contract/01-create.md` (arketipe E1 — field `work_estimation`, `work_log_analytic_account_id`, dan Work Log tab) beserta tour pasangannya (`modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali`)

Tidak ada perubahan perilaku modul — murni perbaikan kepatuhan (refactor).

## Validasi

Keenam validator kepatuhan lolos `status=OK` untuk modul ini:

```
#VALIDATOR name=module    target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_contract_work_log series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`pre-commit-gate.sh`: `GATE OK: 6 pemeriksaan, 0 pelanggaran baru.`

Closes #105