### PR TITLE
[UPD] ssi_service_custom_information - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_custom_information/README.rst
+++ b/ssi_service_custom_information/README.rst
@@ -7,6 +7,12 @@ Service Contract + Custom Information Integration
 =================================================
 
 
+Work Instruction
+================
+
+* `Create Service Contract <docs/service_contract/01-create.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_custom_information/__manifest__.py
+++ b/ssi_service_custom_information/__manifest__.py
@@ -12,7 +12,10 @@
     "depends": [
         "ssi_service",
         "ssi_custom_information_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_custom_information/docs/service_contract/01-create.md
+++ b/ssi_service_custom_information/docs/service_contract/01-create.md
@@ -1,0 +1,30 @@
+# Create Service Contract
+
+> **Module:** ssi_service_custom_information\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`\
+> **Inline Actions:** `action_reload_custom_info_template` (Template),
+> `action_reload_custom_info` (Custom Info)
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Custom Information** page:
+
+- **Template**: The `custom_info.template` used to render this contract's custom
+  properties. Automatically filled once **Type** is selected — the module wires an
+  onchange that looks up the template configured for that **Type**. Clears back to empty
+  if **Type** is cleared. The user may still change it manually afterward.
+- **Custom Properties** (`custom_info_ids`): Grid of custom property values rendered
+  from the selected **Template**. Optional; only meaningful once a **Template** is set.
+
+The page also carries two buttons, provided by the underlying `mixin.custom_info`
+(shipped with `ssi_custom_information_mixin`) rather than by this module's own field
+definitions:
+
+- **Template**: Re-runs the template lookup for the current **Type**, refilling
+  **Template** the same way the onchange does. Use it if **Template** was cleared or
+  changed manually and needs to be reset to the **Type**'s configured value.
+- **Custom Info**: Regenerates the **Custom Properties** rows from the currently
+  selected **Template**. Manual edits already made to existing rows are discarded when
+  this is used.
+
+Neither button is restricted to the Draft status.

--- a/ssi_service_custom_information/models/service_contract.py
+++ b/ssi_service_custom_information/models/service_contract.py
@@ -6,6 +6,13 @@ from odoo import api, models
 
 
 class ServiceContract(models.Model):
+    """
+    Adds custom information support to ``service.contract``.
+    Lets the contract carry a ``custom_info.template`` and its related
+    ``custom_info.value`` records, rendered as an extra notebook page on
+    the contract form.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",
@@ -17,6 +24,12 @@ class ServiceContract(models.Model):
         "type_id",
     )
     def onchange_custom_info_template_id(self):
+        """Resolve the custom info template from the contract type.
+
+        Clears ``custom_info_template_id`` first, then looks up the
+        template configured for the selected ``type_id`` (if any) via
+        ``mixin.custom_info._get_template_custom_info``.
+        """
         self.custom_info_template_id = False
         if self.type_id:
             self.custom_info_template_id = self._get_template_custom_info()

--- a/ssi_service_custom_information/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_custom_information/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,107 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_custom_information.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields: the Custom Information page, its Template/Custom
+    // Properties fields, and the Template/Custom Info reload
+    // buttons). The onchange result and the reload buttons' write
+    // effects are unit-test territory (odoo-development-unit-test);
+    // this tour only proves the create form reaches the page and
+    // that every delta element is actually rendered there.
+    tour.register(
+        "ssi_service_custom_information_service_contract_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Modified Flow (docs/service_contract/01-create.md,
+            // delta of ssi_service_custom_information) — open the
+            // Custom Information page added by this module.
+            {
+                content: "Open the Custom Information tab",
+                trigger: ".o_notebook .nav-link:contains(Custom Information)",
+            },
+
+            // Additional Fields — Template.
+            {
+                content: "The Template field is present",
+                trigger: ".o_field_many2one[name='custom_info_template_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields — Custom Properties grid.
+            {
+                content: "The Custom Properties grid is present",
+                trigger: ".o_field_widget[name='custom_info_ids']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Inline Actions — Template / Custom Info reload buttons,
+            // injected by mixin.custom_info. Delta-only tour: it does
+            // not click them (both write o2m/related data and are
+            // odoo-development-unit-test territory), it only proves
+            // both are rendered and clickable.
+            {
+                content: "The Template reload button is present",
+                trigger: "button[name='action_reload_custom_info_template']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "The Custom Info reload button is present",
+                trigger: "button[name='action_reload_custom_info']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_custom_information/tests/__init__.py
+++ b/ssi_service_custom_information/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_custom_information
+from . import test_ui_service_contract

--- a/ssi_service_custom_information/tests/test_data_service_custom_information.yaml
+++ b/ssi_service_custom_information/tests/test_data_service_custom_information.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Custom Information - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_custom_information/tests/test_service_custom_information.py
+++ b/ssi_service_custom_information/tests/test_service_custom_information.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceCustomInformation(YamlTransactionCase):
+    """
+    Test custom information support added to ``service.contract``.
+    Covers creating a contract and confirming/approving it while the
+    custom info template/value fields are present.
+    """
+
     def test_service_custom_information(self):
+        """Run the create-confirm-approve custom info scenario."""
         self.run_yaml_scenario("test_data_service_custom_information.yaml")

--- a/ssi_service_custom_information/tests/test_ui_service_contract.py
+++ b/ssi_service_custom_information/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so a Pre-Condition fixture would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour test for the custom information delta on ``service.contract``."""
+
+    def test_create(self):
+        """Run the delta create tour asserting the added page/buttons.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_custom_information_service_contract_create",
+            login="admin",
+        )

--- a/ssi_service_custom_information/views/assets.xml
+++ b/ssi_service_custom_information/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_custom_information assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_custom_information/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary

Memperbaiki temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada
modul `ssi_service_custom_information`:

* Modul belum punya `docs/` sama sekali — ditambahkan Instruksi Kerja (IK) extension di
  `docs/service_contract/01-create.md` (mendokumentasikan field `custom_info_template_id`/
  `custom_info_ids` dan tombol reload yang ditambahkan modul ini pada `service.contract`)
  beserta tour UI pasangannya.
* Docstring ditambahkan untuk seluruh class & method yang belum punya (model dan test).
* `invalidate_cache` manual pada skenario YAML dihapus, diganti opsi `auto_refresh`
  bawaan `odoo-yaml-test` — assertion yang sudah ada tidak diubah.

Tidak ada perubahan perilaku fungsional; nama class/method/field tidak diubah.

Closes #106

## Test plan

- [x] `verify-module.sh` → `status=OK` (0 ERROR)
- [x] `validate-ik.sh` → `status=OK` (0 ERROR, 0 peringatan)
- [x] `validate-tour.sh` → `status=OK` (0 ERROR)
- [x] `validate-unit-test.sh` → `status=OK` (0 ERROR; 1 peringatan cakupan onchange di
      luar lingkup backlog audit ini)
- [x] `validate-po.sh` / `validate-web.sh` → `status=OK` (tidak ada yang diperiksa)
- [x] `pre-commit-gate.sh` → `GATE OK`, 0 pelanggaran baru
- [ ] CI hijau