### PR TITLE
[UPD] ssi_service_documenso_signing - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_documenso_signing/README.rst
+++ b/ssi_service_documenso_signing/README.rst
@@ -25,6 +25,11 @@ Usage
 Open any Service Contract record. A new **Documenso** tab will appear in
 the form view, listing all signature requests linked to that contract.
 
+Work Instruction
+================
+
+* `Approve Service Contract <docs/service_contract/index.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_service_documenso_signing/__manifest__.py
+++ b/ssi_service_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_service",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_documenso_signing/docs/service_contract/05-approve.md
+++ b/ssi_service_documenso_signing/docs/service_contract/05-approve.md
@@ -1,0 +1,33 @@
+# Approve Service Contract
+
+> **Module:** ssi_service_documenso_signing
+>
+> **Extends:** ssi_service — model `service.contract`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: on Flow base step 3 (Click the **Approve** button). This module adds a
+  **Signature Requests** page to the form (present from record creation onward, inserted
+  after the last existing tab), showing the **Approval Signature Request** field
+  (`approval_signature_request_id`) plus the record's full signing history.
+- When the matching `approval.template` has a Documenso signing template configured,
+  Confirm (base `04-confirm.md`) already created a single `documenso.signature.request`
+  instead of a per-level approval record, and it is shown in that field. From this point
+  in the base Flow, the manual Approve click described above does not apply to this
+  document: there is no `approval.approval` record for the pending level, so there is
+  nothing to click Approve on for it. Approval is granted automatically once the linked
+  signature request reaches the **Signed** state in Documenso.
+- If the signature request is cancelled instead (e.g. a signer declines in Documenso),
+  this document moves straight to **Rejected** — the same outcome as clicking Reject in
+  the base Flow (`06-reject.md`), but triggered by Documenso instead of by a user
+  action.
+- When the approval template has **no** Documenso signing template configured, the base
+  Flow above applies unchanged; the **Signature Requests** page is still visible but its
+  **Approval Signature Request** field stays empty.
+
+## Additional Post-Condition
+
+- Once the signature request reaches **Signed**, this document completes exactly as
+  described in the base Post-Condition: since the approval template defines a single
+  approver level, status changes directly to **In Progress** and the document number and
+  analytic account are generated automatically as usual.

--- a/ssi_service_documenso_signing/models/service_contract.py
+++ b/ssi_service_documenso_signing/models/service_contract.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class ServiceContract(models.Model):
+    """Add Documenso signature-based approval to ``service.contract``.
+
+    Mixes in ``mixin.documenso_signing_approval`` so that, when the
+    contract's approval template points to a Documenso signing
+    template, confirming the contract creates a signature request
+    instead of the usual approval records. The contract is approved
+    once that request is signed, and rejected if it is cancelled.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",

--- a/ssi_service_documenso_signing/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_documenso_signing/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,110 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_service_documenso_signing.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record -> click Approve -> confirm the
+    // dialog) is retraced from the base IK
+    // ssi_service/docs/service_contract/05-approve.md Flow steps 1-4 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion,
+    // inserted right before the base's Flow step 3, proves the additional
+    // "Signature Requests" page is visible on the form. The approval
+    // template used by this fixture has no Documenso signing template
+    // configured (out of scope -- Ruang Lingkup excludes configuring the
+    // Documenso connector), so the base Approve click still completes the
+    // document normally; that final state assertion proves the action
+    // still finishes end to end with the new page in place.
+    tour.register(
+        "ssi_service_documenso_signing_service_contract_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-DS-SC-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Delta anchor — before clicking Approve (base Flow step 3),
+            // open the Signature Requests page this module adds and prove
+            // it is rendered.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored to the group label, not the (empty) many2one
+                // field -- a readonly field without a value renders as a
+                // zero-pixel element and never becomes a visible trigger
+                // (odoo-development-ui-test skill, patterns.md §O).
+                content:
+                    "Signature Requests page shows the Approval Signing Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Base Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // ── Base Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // ── Additional Post-Condition — the action still completes:
+            // status jumps straight to In Progress, same as the base
+            // Post-Condition.
+            {
+                content: "Status is In Progress",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_documenso_signing/tests/__init__.py
+++ b/ssi_service_documenso_signing/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_documenso_signing
+from . import test_ui_service_contract

--- a/ssi_service_documenso_signing/tests/test_data_service_documenso_signing.yaml
+++ b/ssi_service_documenso_signing/tests/test_data_service_documenso_signing.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name:
       "Service Documenso Signing Approval - Create and Verify (Normal Approval Fallback)"
@@ -62,10 +65,14 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      - step: "Assert contract state after confirm (force cache refresh)"
+        action: "assert"
         target: "contract"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_documenso_signing/tests/test_service_documenso_signing.py
+++ b/ssi_service_documenso_signing/tests/test_service_documenso_signing.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceDocumensoSigning(YamlTransactionCase):
+    """Cover the Documenso signing approval flow on ``service.contract``."""
+
     def test_service_documenso_signing(self):
+        """Run the Documenso signing approval scenario."""
         self.run_yaml_scenario("test_data_service_documenso_signing.yaml")

--- a/ssi_service_documenso_signing/tests/test_ui_service_contract.py
+++ b/ssi_service_documenso_signing/tests/test_ui_service_contract.py
@@ -1,0 +1,69 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour test for the Documenso Signature Requests page on Approve."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one confirmed ``service.contract`` fixture for the tour.
+
+        ``service_contract_validator_group`` already grants
+        ``base.user_admin`` membership by default (see ``ssi_service``'s
+        ``security/res_group_data.xml``), so ``admin`` can both open and
+        approve the fixture without any extra group setup. The record's
+        ``user_id`` is set explicitly to ``admin`` — ``cls.env`` runs as
+        SUPERUSER here, and the record rule
+        ``service_contract_internal_user_rule`` would otherwise hide it
+        from the ``admin`` tour session.
+
+        No ``approval.template`` with a Documenso signing template is
+        configured here — that is server-side Documenso connector setup,
+        out of scope for this module's IK/tour (Ruang Lingkup). The
+        shipped default template therefore drives approval normally, and
+        the tour proves the added Signature Requests page renders
+        alongside that unchanged base flow.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        partner = cls.env["res.partner"].create(
+            {"name": "TOUR DS SC Partner", "is_company": True}
+        )
+        service_type = cls.env["service.type"].create(
+            {"name": "TOUR DS SC Type", "code": "TOURDS"}
+        )
+        cls.rec_approve = cls.env["service.contract"].create(
+            {
+                "partner_id": partner.id,
+                "type_id": service_type.id,
+                "manager_id": cls.admin.id,
+                "salesperson_id": cls.admin.id,
+                "pricelist_id": cls.env.ref("product.list0").id,
+                "currency_id": cls.env.ref("base.USD").id,
+                "date": "2026-01-01",
+                "date_start": "2026-01-01",
+                "date_end": "2026-12-31",
+                "title": "TOUR-DS-SC-APPROVE",
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+    def test_approve(self):
+        """Run the approve tour for ``service.contract``.
+
+        IK: docs/service_contract/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_documenso_signing_service_contract_approve",
+            login="admin",
+        )

--- a/ssi_service_documenso_signing/views/assets.xml
+++ b/ssi_service_documenso_signing/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_documenso_signing/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Perbaikan temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul
`ssi_service_documenso_signing`:

* Tambah docstring pada class & method yang belum punya (model `service.contract` dan
  berkas `tests/`), sesuai gaya reST skill `odoo-development`.
* Hapus `invalidate_cache` manual di skenario YAML, ganti dengan opsi `auto_refresh` +
  step `assert` ber-`refresh: true` sesuai pustaka `odoo-yaml-test` (T-04).
* Tambah Instruksi Kerja (IK) extension untuk `service.contract`
  (`docs/service_contract/05-approve.md`, arketipe E2a) beserta tour pasangannya.
* Tambah bagian *Work Instruction* di `README.rst`.

Tidak ada perubahan perilaku modul yang sudah berjalan.

## Validator

```
#VALIDATOR name=module    target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=opnsynid-service modules=1 failed=0 skipped=0 status=OK
```

Closes #107