### PR TITLE
[UPD] ssi_service_quality_control - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quality_control/README.rst
+++ b/ssi_service_quality_control/README.rst
@@ -6,6 +6,11 @@
 Service - Quality Control Integration
 =====================================
 
+Work Instruction
+=================
+
+* `Create Service Contract <docs/service_contract/index.html>`_
+
 
 Installation
 ============

--- a/ssi_service_quality_control/__manifest__.py
+++ b/ssi_service_quality_control/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2023 OpenSynergy Indonesia
 # Copyright 2023 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
+# pylint: disable=locally-disabled, manifest-required-author
 {
     "name": "Service - Quality Control Integration",
     "version": "14.0.1.0.0",
@@ -11,8 +12,11 @@
     "depends": [
         "ssi_service",
         "ssi_quality_control",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_quality_control/docs/service_contract/01-create.md
+++ b/ssi_service_quality_control/docs/service_contract/01-create.md
@@ -1,0 +1,42 @@
+# Create Service Contract
+
+> **Module:** ssi_service_quality_control\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`\
+> **Inline Actions:** `action_create_qc_worksheet` (Create Worksheet From Set)
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Quality Control** tab:
+
+- **Worksheet Set**: Optional. Selects a `qc_worksheet_set` record — the set of
+  worksheet types that **Create Worksheet From Set** (see below) generates for this
+  contract.
+- **Result Computation Method**: Required. Selection of **Automatic** or **Manual**,
+  defaulting to **Automatic**. Determines whether **Final** (below) is derived from the
+  generated worksheets or entered by hand.
+- **Automatic**: Read-only, computed. `True` only when every worksheet listed in **QC
+  Worksheets** is in state _Done_ and has passed. Only meaningful when **Result
+  Computation Method** is **Automatic**.
+- **Manual**: A plain checkbox, editable at any time regardless of **Result Computation
+  Method**. Used as the value of **Final** when **Result Computation Method** is
+  **Manual**.
+- **Final**: Read-only, computed. Mirrors **Automatic** or **Manual**, whichever
+  **Result Computation Method** selects.
+- **QC Worksheets**: Read-only summary list of the worksheets generated for this
+  contract. Opening a row navigates to that worksheet's own record — filling out a
+  worksheet's questions is done there, not on this form.
+
+## Modified Flow
+
+- Anchor: on the base Flow, before step 5 (**Save**), a **Quality Control** tab is
+  available on the form (alongside **Accounting** and **Analytic & Project**).
+- On the **Quality Control** tab, click **Create Worksheet From Set** to generate one
+  worksheet per type configured in **Worksheet Set**. It does nothing if **Worksheet
+  Set** is empty, and does nothing if **QC Worksheets** already has rows — it does not
+  regenerate or duplicate worksheets that already exist.
+
+## Related Views
+
+- **Open QC Worksheet**: Opens the list of worksheets already generated for this
+  contract, filtered to this record. Navigation only — it does not write any field and
+  is not part of preparing the contract itself.

--- a/ssi_service_quality_control/models/service_contract.py
+++ b/ssi_service_quality_control/models/service_contract.py
@@ -6,6 +6,16 @@ from odoo import models
 
 
 class ServiceContract(models.Model):
+    """Attach quality control worksheets to ``service.contract``.
+
+    Inherits ``mixin.qc_worksheet`` and enables its auto-injected form
+    page (``_qc_worksheet_create_page = True``), giving each service
+    contract a ``Quality Control`` tab where worksheets can be
+    generated from a worksheet set and their aggregated result
+    tracked. See the ``mixin.qc_worksheet`` docstring for the fields
+    and actions it contributes.
+    """
+
     _name = "service.contract"
     _inherit = [
         "service.contract",

--- a/ssi_service_quality_control/static/tests/tours/service_contract_tour.js
+++ b/ssi_service_quality_control/static/tests/tours/service_contract_tour.js
@@ -1,0 +1,86 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_quality_control.service_contract_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_contract/01-create.md (E1 delta — Additional
+    // Fields + Inline Actions: action_create_qc_worksheet)
+    tour.register(
+        "ssi_service_quality_control_service_contract_field_qc_worksheet",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Contracts menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Contracts menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_service.menu_service_contract"]',
+            },
+            {
+                // Gate: wait for the Contracts action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Contracts list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contracts)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_contract/01-create.md,
+            // delta of ssi_service_quality_control) — the Quality
+            // Control tab added by mixin.qc_worksheet. Open it first:
+            // the tab is not the active one by default (patterns.md §
+            // notebook tabs).
+            {
+                content: "Open the Quality Control tab",
+                trigger: ".o_notebook .nav-link:contains(Quality Control)",
+            },
+
+            // Delta-only tour: assert the Worksheet Set field and the
+            // Create Worksheet From Set button are present, then stop.
+            // It does not fill any field and does not continue to Save
+            // (E1 delta-only; see odoo-development-ui-test
+            // scope-and-boundaries.md).
+            {
+                content: "Worksheet Set field is displayed",
+                trigger: ".o_field_widget[name='qc_worksheet_set_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+            {
+                content: "Create Worksheet From Set button is displayed",
+                trigger: "button[name='action_create_qc_worksheet']:enabled",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_quality_control/tests/__init__.py
+++ b/ssi_service_quality_control/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quality_control
+from . import test_ui_service_contract

--- a/ssi_service_quality_control/tests/test_data_service_quality_control.yaml
+++ b/ssi_service_quality_control/tests/test_data_service_quality_control.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Quality Control - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "contract"
-        method: "invalidate_cache"
 
       - step: "Approve contract"
         action: "call"

--- a/ssi_service_quality_control/tests/test_service_quality_control.py
+++ b/ssi_service_quality_control/tests/test_service_quality_control.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestServiceQualityControl(YamlTransactionCase):
+    """Cover the ``service.contract`` quality control worksheet mixin.
+
+    Exercises the confirm/approve flow of ``service.contract`` after
+    installing ``ssi_service_quality_control``, so the mixin's fields
+    stay usable through the base workflow.
+    """
+
     def test_service_quality_control(self):
+        """Run the create-confirm-approve scenario for the contract."""
         self.run_yaml_scenario("test_data_service_quality_control.yaml")

--- a/ssi_service_quality_control/tests/test_ui_service_contract.py
+++ b/ssi_service_quality_control/tests/test_ui_service_contract.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so a Pre-Condition fixture would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceContract(HttpSavepointCase):
+    """Tour tests for the ``service.contract`` QC worksheet delta."""
+
+    def test_field_qc_worksheet(self):
+        """Run the delta tour for the ``service.contract`` create form.
+
+        IK: docs/service_contract/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quality_control_service_contract_field_qc_worksheet",
+            login="admin",
+        )

--- a/ssi_service_quality_control/views/assets.xml
+++ b/ssi_service_quality_control/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quality_control assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quality_control/static/tests/tours/service_contract_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan audit kepatuhan (sapuan `audit-sweep.sh 14.0 --repo opnsynid-service`, 14 Agustus 2026) pada modul `ssi_service_quality_control`, tanpa mengubah perilaku modul yang sudah berjalan:

* Menambahkan Instruksi Kerja (IK) extension untuk `service.contract` di `docs/service_contract/01-create.md` beserta tour UI test pasangannya (satu file IK = satu tour).
* Menambahkan docstring reST (bahasa Inggris, ≤ 79 karakter) untuk class model dan class/method test yang sebelumnya belum berdocstring.
* Menghapus pemanggilan `invalidate_cache` manual di skenario YAML unit test, diganti opsi `auto_refresh` milik pustaka `odoo-yaml-test`. Assertion yang sudah ada tidak diubah.

## Test plan

- [x] `verify-module.sh` — `status=OK`, 0 ERROR
- [x] `validate-ik.sh` — `status=OK`, 0 ERROR
- [x] `validate-tour.sh` — `status=OK`, 0 ERROR
- [x] `validate-unit-test.sh` — `status=OK`, 0 ERROR
- [x] `pre-commit-gate.sh` — `GATE OK`, 0 pelanggaran baru
- [ ] CI hijau (menunggu GitHub Actions)

Closes #110