### PR TITLE
[UPD] ssi_service_quotation_custom_information - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_custom_information/README.rst
+++ b/ssi_service_quotation_custom_information/README.rst
@@ -19,6 +19,12 @@ To install this module, you need to:
 5.  Search For *Service Quotation + Custom Information Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/01-create.html>`_
+* `Mark Service Quotation as Win <docs/service_quotation/07-win.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_service_quotation_custom_information/__manifest__.py
+++ b/ssi_service_quotation_custom_information/__manifest__.py
@@ -12,7 +12,10 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_custom_information_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
 }

--- a/ssi_service_quotation_custom_information/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_custom_information/docs/service_quotation/01-create.md
@@ -1,0 +1,17 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_custom_information\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the **Custom Information** tab is added to the form
+(after the last existing tab):
+
+- **Custom Information Template**: Automatically set when **Type** is filled in —
+  resolved from the `custom.info.template` records that apply to `service.quotation`,
+  evaluated in sequence order. Read-only; not picked manually by the user.
+- **Custom Properties**: One row per property defined by the resolved **Custom
+  Information Template**. Rows appear automatically once the template is set; the user
+  fills in each row's **Value** as needed. Rows are removed automatically if the
+  template no longer defines that property.

--- a/ssi_service_quotation_custom_information/docs/service_quotation/07-win.md
+++ b/ssi_service_quotation_custom_information/docs/service_quotation/07-win.md
@@ -1,0 +1,11 @@
+# Mark Service Quotation as Win
+
+> **Module:** ssi_service_quotation_custom_information\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `07-win`
+
+## Additional Post-Condition
+
+- The **Custom Properties** values filled in on the quotation's **Custom Information**
+  tab are copied to the same properties on the newly created **Service Contract**,
+  matched by property. This happens automatically as part of clicking **Win**; there is
+  no extra step in the Flow.

--- a/ssi_service_quotation_custom_information/models/service_quotation.py
+++ b/ssi_service_quotation_custom_information/models/service_quotation.py
@@ -6,6 +6,13 @@ from odoo import api, models
 
 
 class ServiceQuotation(models.Model):
+    """
+    Adds custom information (``mixin.custom_info``) support to service
+    quotations. Lets each service type carry its own custom info
+    template, and propagates the filled-in values to the ``service.contract``
+    generated when the quotation is won.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
@@ -17,11 +24,27 @@ class ServiceQuotation(models.Model):
         "type_id",
     )
     def onchange_custom_info_template_id(self):
+        """Reset the custom info template based on the selected type.
+
+        Clears ``custom_info_template_id`` first, then re-assigns it
+        from the template configured on ``type_id`` (if any) via
+        ``_get_template_custom_info``.
+        """
         self.custom_info_template_id = False
         if self.type_id:
             self.custom_info_template_id = self._get_template_custom_info()
 
     def _create_contract(self):
+        """Copy filled custom info values into the generated contract.
+
+        Extends the base contract creation: after ``super()`` builds
+        ``contract_id``, this removes any custom info values the
+        contract creation already generated from its own template,
+        reloads the template on the contract, then copies over the
+        values entered on this quotation — matched by
+        ``detail_id.property_id`` — so the contract starts with the
+        same custom info the quotation had.
+        """
         self.ensure_one()
         _super = super(ServiceQuotation, self)
         _super._create_contract()

--- a/ssi_service_quotation_custom_information/static/tests/tours/service_quotation_custom_information_tour.js
+++ b/ssi_service_quotation_custom_information/static/tests/tours/service_quotation_custom_information_tour.js
@@ -1,0 +1,78 @@
+odoo.define(
+    "ssi_service_quotation_custom_information.service_quotation_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/service_quotation/01-create.md (delta)
+        //
+        // Delta-only tour (arketipe E1): navigation is taken from the base
+        // `ssi_service_quotation` create tour (open menu, click New), then
+        // this module's own contribution — the Custom Information tab — is
+        // asserted to be rendered. It does not continue to save/confirm;
+        // that remains fully covered by the base tour.
+        tour.register(
+            "ssi_service_quotation_custom_information_service_quotation_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    // ── Flow 1 — Open the Service > Quotations menu.
+                    content: "Open the Service app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+                },
+                {
+                    content: "Open the Quotations menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+                },
+                {
+                    content: "Quotations list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; gate before touching the list.
+                    },
+                },
+                {
+                    // ── Flow 2 — Click the New button.
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    // ── Additional Fields — Custom Information tab.
+                    content: "Open the Custom Information tab",
+                    trigger: ".o_notebook .nav-link:contains(Custom Information)",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                },
+                {
+                    // Anchor on the field's own label, not on the (empty,
+                    // readonly-looking) many2one widget itself — an unset
+                    // Template value renders as a zero-width element and
+                    // the trigger would never match it.
+                    content: "Custom Information tab shows the Template field",
+                    trigger: ".o_form_label:contains(Template)",
+                    run: function () {
+                        // Assertion only. Post-Condition: the additional
+                        // Custom Information tab and its Template field
+                        // are rendered on the create form.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_service_quotation_custom_information/tests/__init__.py
+++ b/ssi_service_quotation_custom_information/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_custom_information
+from . import test_ui_service_quotation_custom_information

--- a/ssi_service_quotation_custom_information/tests/test_data_service_quotation_custom_information.yaml
+++ b/ssi_service_quotation_custom_information/tests/test_data_service_quotation_custom_information.yaml
@@ -61,10 +61,14 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      - step: "Force cache refresh before approve (see T-04)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_custom_information/tests/test_service_quotation_custom_information.py
+++ b/ssi_service_quotation_custom_information/tests/test_service_quotation_custom_information.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotCustomInfo(YamlTransactionCase):
+    """Cover custom info on ``service.quotation`` end to end.
+
+    Exercises creating a quotation, confirming and approving it, and
+    verifying the custom info flow via the YAML scenario below.
+    """
+
     def test_service_quotation_custom_information(self):
+        """Run the create/confirm/approve custom info scenario."""
         self.run_yaml_scenario("test_data_service_quotation_custom_information.yaml")

--- a/ssi_service_quotation_custom_information/tests/test_ui_service_quotation_custom_information.py
+++ b/ssi_service_quotation_custom_information/tests/test_ui_service_quotation_custom_information.py
@@ -1,0 +1,34 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotationCustomInformation(HttpSavepointCase):
+    """Tour test for the ``service.quotation`` custom info delta IK."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set the admin user so the tour session has access.
+
+        No extra record is created: the delta tour only opens the
+        create form and asserts the additional tab, it never saves.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+    def test_create(self):
+        """Run the create delta tour for ``service.quotation``.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_custom_information_service_quotation_create",
+            login="admin",
+        )

--- a/ssi_service_quotation_custom_information/views/assets.xml
+++ b/ssi_service_quotation_custom_information/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_service_quotation_custom_information assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_service_quotation_custom_information/static/tests/tours/service_quotation_custom_information_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 9 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service`
pada modul `ssi_service_quotation_custom_information`:

* Menambahkan Instruksi Kerja (IK) extension di `docs/service_quotation/` (`01-create.md`,
  `07-win.md`) beserta tour delta pasangannya — modul ini sebelumnya belum punya IK sama sekali.
* Melengkapi docstring reST (bahasa Inggris, ≤ 79 karakter) untuk seluruh class & method yang
  belum punya, termasuk class test, `setUpClass`, dan method `test_*` di `tests/`.
* Mengganti `invalidate_cache` manual di skenario YAML dengan step `assert` ber-`refresh: true`
  (pola resmi T-04 di `odoo-development-unit-test`), tanpa mengubah nilai yang di-assert.

Tidak ada perubahan perilaku modul — hanya dokumentasi, docstring, dan mekanisme cache refresh
pada test.

## Kriteria Penerimaan

- [x] `validate-ik.sh` dan `validate-tour.sh` keduanya `status=OK`
- [x] `verify-module.sh` tidak lagi melaporkan `setiap-class-method-punya-docstring`
- [x] `validate-unit-test.sh` tidak lagi melaporkan `setiap-class-method-test-punya-docstring`
- [x] Tidak ada lagi `invalidate_cache` di berkas YAML modul ini
- [x] Keenam validator (`module`, `ik`, `po`, `web`, `unit-test`, `tour`) `status=OK` — lihat
  `pre-commit-gate.sh` di bawah

## Bukti validator

```
#VALIDATOR name=module    target=ssi_service_quotation_custom_information series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_quotation_custom_information series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_quotation_custom_information series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_quotation_custom_information series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_quotation_custom_information series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_quotation_custom_information series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=opnsynid-service modules=1 failed=0 skipped=0 status=OK
```

Peringatan `unit-test` (1) adalah cakupan `@api.onchange` via `action: form`, secara eksplisit
di luar lingkup backlog audit ini (lihat `## Ruang Lingkup` di issue).

Closes #112