### PR TITLE
[UPD] ssi_service_quotation_documenso_signing - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_documenso_signing/README.rst
+++ b/ssi_service_quotation_documenso_signing/README.rst
@@ -25,6 +25,12 @@ Usage
 Open any Service Quotation record. A new **Documenso** tab will appear in
 the form view, listing all signature requests linked to that quotation.
 
+Work Instruction
+================
+
+* `Approve Service Quotation <docs/service_quotation/index.html>`_
+* `Create Signing Request for Service Quotation <docs/service_quotation/index.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_service_quotation_documenso_signing/__manifest__.py
+++ b/ssi_service_quotation_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_service_quotation_documenso_signing/docs/service_quotation/05-approve.md
+++ b/ssi_service_quotation_documenso_signing/docs/service_quotation/05-approve.md
@@ -1,0 +1,38 @@
+# Approve Service Quotation
+
+> **Module:** ssi_service_quotation_documenso_signing
+>
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: at Flow base step 2 (open the record to approve), the form already shows a
+  **Signature Requests** tab (injected because `_documenso_signing_create_page = True`).
+  This tab is always present once this module is installed, regardless of whether
+  Documenso signing is actually used for the current approval.
+- The behavior below only applies **when the record's active Approval Template has a
+  Documenso Signing Template configured**. If it does not, the base Flow (steps 3–4,
+  Click **Approve** / click **OK**) applies unchanged, exactly as documented in
+  `ssi_service_quotation/docs/service_quotation/05-approve.md`.
+- When a Documenso Signing Template **is** configured: no per-approver approval record
+  is created for this document — a single `documenso.signature.request` is created and
+  linked instead (during the earlier Confirm action, before this record reaches
+  **Waiting for Approval**). Because there is no per-approver record naming the current
+  user as an active approver, the **Approve** button (Flow base step 3) stays invisible
+  for every user — it can never be clicked.
+- Instead of clicking Approve, the user opens the linked request — shown under the
+  **Approval Signing Request** group as the **Approval Signature Request** field in the
+  **Signature Requests** tab (or via the **Open Signature Requests** button in the same
+  tab) — and, on that request's own form, clicks **Send to Documenso** to send the
+  document for e-signature. The designated signer(s) then sign the document outside
+  Odoo, in Documenso.
+- Approval completes automatically — without any button click on this Service Quotation
+  record — once the linked signature request reaches the **Signed** status (checked
+  manually via **Check Status** on the request, or synced automatically by the
+  connector). At that point, the base Post-Condition applies as usual: status
+  automatically changes to **In Progress** (or remains **Waiting for Approval** if other
+  approval levels are still pending).
+- If the linked signature request is **cancelled** instead (e.g. a signer declines in
+  Documenso), the record moves directly to **Rejected** — the same end state as the base
+  Reject action, but triggered automatically by the cancelled request rather than by a
+  user clicking Reject.

--- a/ssi_service_quotation_documenso_signing/docs/service_quotation/06-create-signing-request.md
+++ b/ssi_service_quotation_documenso_signing/docs/service_quotation/06-create-signing-request.md
@@ -1,0 +1,50 @@
+# Create Signing Request for Service Quotation
+
+> **Module:** ssi_service_quotation_documenso_signing\
+> **Model:** `service.quotation`\
+> **Menu:** Service > Quotations\
+> **Actor:** user in group `Service Quotation - User`\
+> **Requires:** `ssi_service_quotation/service_quotation/01-create`\
+> **Extends:** ssi_service_quotation — model `service.quotation`
+
+## Pre-Condition
+
+- **Record:** A `service.quotation` record exists. The **Signature Requests** tab is
+  present on the form regardless of status, since
+  `_documenso_signing_create_page = True` is set unconditionally by this module.
+- **Config:** An active `documenso.signing.template` exists with **Source Model** set to
+  `service.quotation` and a **Py3o Report** configured. The Py3o Report is required
+  because the created `documenso.signature.request` copies it from the template and
+  requires it to save; without one, clicking **Create** in step 6 fails.
+- **Config:** An active `documenso.backend` exists.
+- **Access:** User is in group `Service Quotation - User` — the button carries no
+  additional group restriction beyond normal record access.
+
+## Flow
+
+1. Open the **Service > Quotations** menu.
+2. Open the record.
+3. Open the **Signature Requests** tab.
+4. Click the **New Signing Request** button.
+5. In the wizard that appears, fill in:
+   - **Signing Template** _(required)_: select the Documenso Signing Template configured
+     for **Service Quotation**.
+   - **Backend**: Automatically filled with the active Documenso Backend. Change if
+     needed.
+6. Click **Create**. The browser navigates to the newly created signature request's own
+   form.
+7. Return to the **Service > Quotations** menu, open the same record again, and open the
+   **Signature Requests** tab.
+
+## Post-Condition
+
+- A new row appears in the list on the **Signature Requests** tab, for the signature
+  request just created. The row's field values are not asserted.
+- This action does not move `service.quotation`'s own status.
+
+## Note — Open Signature Requests button
+
+- The **Open Signature Requests** button on the same **Signature Requests** tab
+  (`action_open_signature_requests`) is verdict **N** (nol IK): it only returns an
+  `ir.actions.act_window` that opens the list of this record's signature requests — it
+  writes no field. No IK or tour is written for it.

--- a/ssi_service_quotation_documenso_signing/models/service_quotation.py
+++ b/ssi_service_quotation_documenso_signing/models/service_quotation.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """Adds Documenso electronic signature support to service quotations.
+
+    Extends ``service.quotation`` with
+    ``mixin.documenso_signing_approval`` so the quotation approval flow
+    can be driven by a Documenso signature request instead of manual
+    approvers. Setting ``_documenso_signing_create_page`` to ``True``
+    injects the Documenso signing tab into the quotation form view.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",

--- a/ssi_service_quotation_documenso_signing/static/tests/tours/service_quotation_tour.js
+++ b/ssi_service_quotation_documenso_signing/static/tests/tours/service_quotation_tour.js
@@ -1,0 +1,244 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_service_quotation_documenso_signing.service_quotation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared "open the Service > Quotations menu" steps, matching the base
+    // IK ssi_service_quotation/docs/service_quotation Flow step 1.
+    function openQuotationsMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                // Gate: wait for the TARGET action to be mounted, not just
+                // any list view (the app may land on a stale list first).
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    function openRecordSteps(title) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + title + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record form is displayed",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/service_quotation/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record) is retraced from the base IK
+    // ssi_service_quotation/docs/service_quotation/05-approve.md Flow
+    // steps 1-2 -- see skill odoo-development-ui-test,
+    // scope-and-boundaries.md §3 ("E2a -- telusur-ulang aksi itu dari base
+    // sampai titik ubah"). The delta assertion, anchored at base Flow step
+    // 2 (open the record to approve), verifies the Signature Requests tab
+    // injected because `_documenso_signing_create_page = True`, then stops
+    // -- base Flow steps 3-4 (Approve / OK) and the resulting In Progress
+    // status are NOT exercised here, since whether the Approve button is
+    // even visible depends on whether the active Approval Template has a
+    // Documenso Signing Template configured, and this tour's fixture
+    // leaves that unconfigured. The final signed/rejected outcome is
+    // driven by the external Documenso connector and out of scope for a
+    // tour (Keputusan Desain, issue
+    // open-synergy/opnsynid-service#113).
+    tour.register(
+        "ssi_service_quotation_documenso_signing_service_quotation_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openQuotationsMenuSteps(),
+            openRecordSteps("Tour SQ Documenso Approve"),
+            [
+                // ── Delta assertion (anchor: base Flow step 2) — the
+                // Signature Requests tab is always present once this
+                // module is installed, regardless of whether Documenso
+                // signing is actually used for the current approval.
+                {
+                    content: "Open the Signature Requests tab",
+                    trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+                },
+                {
+                    // Anchored on the group label rather than the
+                    // (currently empty) `approval_signature_request_id`
+                    // many2one widget itself -- a many2one rendered with
+                    // no value has no text node inside its link, so it
+                    // collapses to a zero-size box and jQuery's
+                    // `:visible` (offsetWidth/offsetHeight) never matches
+                    // it, hanging the tour until timeout. The group
+                    // label always has text, so it is a stable proxy for
+                    // "the Approval Signing Request group is rendered".
+                    content:
+                        "Signature Requests tab shows the Approval Signing " +
+                        "Request group",
+                    trigger:
+                        ".o_horizontal_separator:contains(Approval Signing Request)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action. The tour stops here -- it does not click
+                        // Approve, does not assert a final state, and
+                        // never calls the external Documenso service.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/service_quotation/06-create-signing-request.md (E3 -- new
+    // action). The tour runs the wizard to completion (Create), which
+    // navigates to the newly created documenso.signature.request's own
+    // form -- it does NOT go further and click that request's own "Send
+    // to Documenso" button, since that would call the external Documenso
+    // service over the network. After the wizard, the tour returns to the
+    // Service Quotation record and re-opens the Signature Requests tab to
+    // observe the new row -- the row's field values are not asserted
+    // (Keputusan Desain, issue open-synergy/opnsynid-service#113).
+    tour.register(
+        "ssi_service_quotation_documenso_signing_service_quotation" +
+            "_create_signing_request",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openQuotationsMenuSteps(),
+            openRecordSteps("Tour SQ Documenso Signing Request"),
+            [
+                // ── Flow 3 — Open the Signature Requests tab.
+                {
+                    content: "Open the Signature Requests tab",
+                    trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+                },
+
+                // ── Flow 4 — Click the New Signing Request button.
+                {
+                    content: "Click the New Signing Request button",
+                    trigger:
+                        ".o_form_view button[name='action_create_signing_request']",
+                },
+
+                // ── Flow 5 — In the wizard that appears, fill in Signing
+                // Template (Backend is filled automatically).
+                {
+                    // 14.0: do not prefix the trigger with `.modal` -- the
+                    // tour manager already searches inside the modal, and
+                    // `.modal .o_form_view` would look for a nested modal
+                    // that does not exist (patterns.md §H).
+                    content: "The Create Signing Request wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+                {
+                    content: "Select the Signing Template",
+                    trigger: ".o_field_many2one[name='signing_template_id'] input",
+                    run: "text Tour SQ Documenso Signing Template",
+                },
+                {
+                    content: "Pick the Signing Template from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(Tour SQ " +
+                        "Documenso Signing Template)",
+                    in_modal: false,
+                },
+
+                // ── Flow 6 — Click Create. The browser navigates to the
+                // newly created signature request's own form.
+                {
+                    content: "Click Create",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+                {
+                    // The button's return action keeps the existing
+                    // breadcrumb trail and appends the new record's OWN
+                    // display_name (`name_get()` on
+                    // documenso.signature.request, e.g. "*20 - Tour SQ
+                    // Documenso Backend (draft)") -- it is NOT the static
+                    // act_window "name" ("Signature Request"), and that
+                    // display name is data-dependent (source record id +
+                    // backend + state), so it is not a stable string to
+                    // assert on. Anchor instead on the "Py3o Report"
+                    // field, which only exists on
+                    // documenso.signature.request's own form (never on
+                    // the wizard or on service.quotation), and is filled
+                    // with the fixture's report name -- a gate that
+                    // cannot match anywhere earlier in this tour.
+                    content: "The new Signature Request's own form is displayed",
+                    trigger:
+                        ".o_field_widget[name='py3o_report_id']:contains(Tour SQ " +
+                        "Documenso Py3o Report)",
+                    extra_trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action. The tour does NOT click "Send to
+                        // Documenso" here -- that would call the
+                        // external Documenso service.
+                    },
+                },
+
+                // ── Flow 7 — Return to the Quotations menu, reopen the
+                // same record, and open the Signature Requests tab again.
+            ].concat(openQuotationsMenuSteps(), [
+                {
+                    content: "Reopen the record",
+                    trigger:
+                        ".o_data_row:contains(Tour SQ Documenso Signing " +
+                        "Request) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Reopen the Signature Requests tab",
+                    trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+                },
+
+                // ── Post-Condition — a new row appears on the
+                // Signature Requests page for the request just
+                // created. Its field values are not asserted
+                // (Keputusan Desain).
+                {
+                    content: "A new row appears on the Signature Requests page",
+                    trigger:
+                        ".o_field_widget[name='signature_request_ids'] " +
+                        ".o_data_row",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+            ])
+        )
+    );
+});

--- a/ssi_service_quotation_documenso_signing/tests/__init__.py
+++ b/ssi_service_quotation_documenso_signing/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_documenso_signing
+from . import test_ui_service_quotation_documenso_signing

--- a/ssi_service_quotation_documenso_signing/tests/test_data_service_quotation_documenso_signing.yaml
+++ b/ssi_service_quotation_documenso_signing/tests/test_data_service_quotation_documenso_signing.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name:
       "Service Quotation Documenso Signing Approval - Create and Verify (Normal Approval
@@ -62,11 +65,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "quotation"
-        method: "invalidate_cache"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_documenso_signing/tests/test_service_quotation_documenso_signing.py
+++ b/ssi_service_quotation_documenso_signing/tests/test_service_quotation_documenso_signing.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotDocumensoSigning(YamlTransactionCase):
+    """Test the Documenso signing mixin on ``service.quotation``."""
+
     def test_service_quotation_documenso_signing(self):
+        """Run the normal-approval-fallback scenario."""
         self.run_yaml_scenario("test_data_service_quotation_documenso_signing.yaml")

--- a/ssi_service_quotation_documenso_signing/tests/test_ui_service_quotation_documenso_signing.py
+++ b/ssi_service_quotation_documenso_signing/tests/test_ui_service_quotation_documenso_signing.py
@@ -1,0 +1,127 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotationDocumensoSigning(HttpSavepointCase):
+    """Tour tests for the ``service.quotation`` Documenso signing delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create fixtures for both tours in this test class.
+
+        One quotation is moved to ``confirm`` in Python
+        (``action_confirm()`` with ``bypass_policy_check``), not via UI
+        clicks, per Keputusan Desain (issue
+        open-synergy/opnsynid-service#113). A second, separate
+        quotation plus an active Documenso backend and signing
+        template are created for the New Signing Request tour.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Tour SQ Documenso Partner",
+                "is_company": True,
+            }
+        )
+        cls.service_type = cls.env["service.type"].create(
+            {
+                "name": "Tour SQ Documenso Type",
+                "code": "TOURSQDCTYPE",
+            }
+        )
+        base_values = {
+            "partner_id": cls.partner.id,
+            "type_id": cls.service_type.id,
+            "manager_id": cls.admin.id,
+            "salesperson_id": cls.admin.id,
+            "date": "2026-01-01",
+            "date_start": "2026-01-01",
+            "date_end": "2026-12-31",
+            "currency_id": cls.env.ref("base.USD").id,
+            "pricelist_id": cls.env.ref("product.list0").id,
+        }
+
+        # Pre-Condition IK 05-approve.md (delta): record already Waiting
+        # for Approval. The active approval template has no Documenso
+        # Signing Template configured, so the Signature Requests tab is
+        # present (``_documenso_signing_create_page = True``) but the
+        # base Approve/OK Flow is unaffected -- this tour does not
+        # exercise it.
+        cls.quotation_approve = cls.env["service.quotation"].create(
+            dict(base_values, title="Tour SQ Documenso Approve")
+        )
+        cls.quotation_approve.sudo().with_context(
+            bypass_policy_check=True
+        ).action_confirm()
+
+        # Pre-Condition IK 06-create-signing-request.md: an active
+        # documenso.backend and an active documenso.signing.template
+        # (Source Model = service.quotation) must exist, plus a
+        # service.quotation record whose form shows the Signature
+        # Requests tab (any status -- the tab is unconditional).
+        cls.quotation_signing_request = cls.env["service.quotation"].create(
+            dict(base_values, title="Tour SQ Documenso Signing Request")
+        )
+        cls.documenso_backend = cls.env["documenso.backend"].create(
+            {
+                "name": "Tour SQ Documenso Backend",
+                "base_url": "https://documenso.example.com",
+                "api_key": "tour-test-api-key",
+            }
+        )
+        # ``documenso.signature.request.py3o_report_id`` is required, and
+        # the wizard copies it from the signing template's
+        # ``py3o_report_id`` on confirm -- without a matching report the
+        # create() call in ``action_confirm`` raises a validation error
+        # and the wizard never closes. ``ssi_service_quotation`` ships no
+        # py3o report of its own, so a minimal one is created here for
+        # the tour's fixture only.
+        cls.documenso_py3o_report = cls.env["ir.actions.report"].create(
+            {
+                "name": "Tour SQ Documenso Py3o Report",
+                "model": "service.quotation",
+                "report_name": ("ssi_service_quotation_documenso_signing.tour_report"),
+                "report_type": "py3o",
+                "py3o_filetype": "pdf",
+            }
+        )
+        cls.documenso_signing_template = cls.env["documenso.signing.template"].create(
+            {
+                "name": "Tour SQ Documenso Signing Template",
+                "code": "TOURSQDCST",
+                "res_model": "service.quotation",
+                "py3o_report_id": cls.documenso_py3o_report.id,
+            }
+        )
+
+    def test_approve(self):
+        """Run the approve tour for the Documenso signing delta.
+
+        IK: docs/service_quotation/05-approve.md (E2a delta -- Modified
+        Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_documenso_signing_service_quotation_approve",
+            login="admin",
+        )
+
+    def test_create_signing_request(self):
+        """Run the New Signing Request tour on ``service.quotation``.
+
+        IK: docs/service_quotation/06-create-signing-request.md (E3 --
+        new action). The tour stops once the new row appears on the
+        Signature Requests page; it does not click into the created
+        request's own form to send it to Documenso over the network.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_documenso_signing_service_quotation"
+            "_create_signing_request",
+            login="admin",
+        )

--- a/ssi_service_quotation_documenso_signing/views/assets.xml
+++ b/ssi_service_quotation_documenso_signing/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quotation_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quotation_documenso_signing/static/tests/tours/service_quotation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 butir temuan audit kepatuhan (`audit-sweep.sh 14.0 --repo opnsynid-service`) pada modul `ssi_service_quotation_documenso_signing`:

* Modul belum punya direktori `docs/` — kini punya IK extension (`05-approve.md` delta E2a, `06-create-signing-request.md` E3) beserta tour pasangannya.
* Docstring lengkap pada class model dan class/method test yang belum punya.
* `invalidate_cache` manual di skenario YAML dihapus, diganti opsi `auto_refresh` pustaka `odoo-yaml-test` (mengikuti pola yang sama dengan `ssi_service_quotation` di PR #141).

Tidak ada perubahan perilaku modul.

## Validator (dijalankan setelah perubahan kode terakhir)

```
#VALIDATOR name=module    target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=.../ssi_service_quotation_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`pre-commit-gate.sh`: `#GATE repo=opnsynid-service modules=1 failed=0 skipped=0 status=OK`

Closes #113