### PR TITLE
[UPD] ssi_service_quotation_operating_unit - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_operating_unit/README.rst
+++ b/ssi_service_quotation_operating_unit/README.rst
@@ -7,6 +7,12 @@ Service Quotation + Operating Unit
 ==================================
 
 
+Work Instruction
+================
+
+* `Create Service Quotation <docs/service_quotation/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_service_quotation_operating_unit/__manifest__.py
+++ b/ssi_service_quotation_operating_unit/__manifest__.py
@@ -12,11 +12,13 @@
     "depends": [
         "ssi_service_quotation",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/service_quotation.xml",
         "security/ir_rule/service_quotation.xml",
         "views/service_quotation_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_service_quotation_operating_unit/docs/service_quotation/01-create.md
+++ b/ssi_service_quotation_operating_unit/docs/service_quotation/01-create.md
@@ -1,0 +1,28 @@
+# Create Service Quotation
+
+> **Module:** ssi_service_quotation_operating_unit\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed and the current company has multiple operating units
+enabled (group `operating_unit.group_multi_operating_unit`), the create form gains one
+field:
+
+- **Operating Unit**: The operating unit the quotation belongs to. Not required.
+  Defaults to the user's default operating unit; may be left as the default or changed
+  by the user before Save.
+
+## Modified — Record Visibility
+
+- The quotation list is now filtered by operating unit (record rule). A user in group
+  **Operating Unit** only sees quotations whose **Operating Unit** is one of the
+  operating units assigned to them. This is not a Flow step.
+
+## Additional Post-Condition
+
+- When the quotation is won and a `service.contract` is generated from it
+  (`_prepare_contract_data`), the created contract's **Operating Unit** is stamped with
+  this quotation's own **Operating Unit**, instead of falling back to the acting user's
+  own default operating unit. This is not a new Flow step; it only changes the Operating
+  Unit recorded on the generated contract.

--- a/ssi_service_quotation_operating_unit/models/service_quotation.py
+++ b/ssi_service_quotation_operating_unit/models/service_quotation.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """
+    Adds Operating Unit traceability to service quotations.
+    Links each quotation to the operating unit it belongs to, drives the
+    OU-scoped record rule, and propagates that operating unit to the
+    ``service.contract`` created from the quotation, instead of falling
+    back to the acting user's own default operating unit.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
@@ -13,6 +21,15 @@ class ServiceQuotation(models.Model):
     ]
 
     def _prepare_contract_data(self):
+        """Build the ``service.contract`` values, stamped with this OU.
+
+        Extends the base ``_prepare_contract_data`` so the contract
+        generated when the quotation is won carries the quotation's own
+        ``operating_unit_id`` (Pola A propagation), rather than the OU
+        default of the user who triggers the win action.
+
+        :return: dict of ``service.contract`` values
+        """
         self.ensure_one()
         _super = super(ServiceQuotation, self)
         result = _super._prepare_contract_data()

--- a/ssi_service_quotation_operating_unit/static/tests/tours/service_quotation_tour.js
+++ b/ssi_service_quotation_operating_unit/static/tests/tours/service_quotation_tour.js
@@ -1,0 +1,78 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_service_quotation_operating_unit.service_quotation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/service_quotation/01-create.md (E1 delta — Additional
+    // Fields)
+    tour.register(
+        "ssi_service_quotation_operating_unit_service_quotation_field_ou",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Base Flow 1 — Open the Service > Quotations menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Service app",
+                trigger: '.o_app[data-menu-xmlid="ssi_service.menu_root_service"]',
+            },
+            {
+                content: "Open the Quotations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_service_quotation.menu_service_quotation"]',
+            },
+            {
+                // Gate: wait for the Quotations action to actually be
+                // mounted, not just any list view left over from the
+                // landing action (patterns.md §A).
+                content: "Quotations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Quotations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Base Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // Additional Fields (docs/service_quotation/01-create.md,
+            // delta of ssi_service_quotation_operating_unit) — the
+            // Operating Unit field added by mixin.single_operating_unit
+            // is rendered on the create form for a user in the multi
+            // operating unit group. Delta-only tour: it stops here, it
+            // does not fill any field and does not continue to Save
+            // (E1 delta-only; the Modified — Record Visibility and
+            // Additional Post-Condition parts of the IK are not covered
+            // by a tour, see odoo-development-ui-test
+            // scope-and-boundaries.md).
+            {
+                content: "Operating Unit field is displayed",
+                trigger: ".o_field_widget[name='operating_unit_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_service_quotation_operating_unit/tests/__init__.py
+++ b/ssi_service_quotation_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_service_quotation_operating_unit
+from . import test_ui_service_quotation

--- a/ssi_service_quotation_operating_unit/tests/test_data_service_quotation_operating_unit.yaml
+++ b/ssi_service_quotation_operating_unit/tests/test_data_service_quotation_operating_unit.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Service Quotation Operating Unit - Create and Verify"
     steps:
@@ -60,11 +63,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "quotation"
-        method: "invalidate_cache"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_operating_unit/tests/test_service_quotation_operating_unit.py
+++ b/ssi_service_quotation_operating_unit/tests/test_service_quotation_operating_unit.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotOperatingUnit(YamlTransactionCase):
+    """Cover the ``service.quotation`` Operating Unit confirm/approve flow."""
+
     def test_service_quotation_operating_unit(self):
+        """Run the create/confirm/approve scenario for the quotation."""
         self.run_yaml_scenario("test_data_service_quotation_operating_unit.yaml")

--- a/ssi_service_quotation_operating_unit/tests/test_ui_service_quotation.py
+++ b/ssi_service_quotation_operating_unit/tests/test_ui_service_quotation.py
@@ -1,0 +1,37 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's plain HttpCase does not set up
+# cls.env in setUpClass, so the Pre-Condition fixture below would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiServiceQuotation(HttpSavepointCase):
+    """Tour tests for the ``service.quotation`` operating unit delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to see the Operating Unit field.
+
+        The multi operating unit group is required for the Operating
+        Unit field itself to be rendered on the create form.
+        """
+        super().setUpClass()
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.user_admin.id)]}
+        )
+
+    def test_field_ou(self):
+        """Run the delta tour for the ``service.quotation`` create form.
+
+        IK: docs/service_quotation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_service_quotation_operating_unit_service_quotation_field_ou",
+            login="admin",
+        )

--- a/ssi_service_quotation_operating_unit/views/assets.xml
+++ b/ssi_service_quotation_operating_unit/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_service_quotation_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_service_quotation_operating_unit/static/tests/tours/service_quotation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_quotation_operating_unit`:

* Tambahkan docstring class & method di `models/service_quotation.py` (`ServiceQuotation`, `_prepare_contract_data`).
* Tambahkan docstring class & method test di `tests/test_service_quotation_operating_unit.py`.
* Hapus `invalidate_cache` manual di skenario YAML, ganti opsi `auto_refresh` milik pustaka `odoo-yaml-test`.
* Tambahkan Instruksi Kerja `docs/service_quotation/01-create.md` (IK extension delta — field Operating Unit, visibility record rule, propagasi OU ke `service.contract`).
* Tambahkan tour pasangan IK (`static/tests/tours/service_quotation_tour.js`) + `views/assets.xml` + `tests/test_ui_service_quotation.py`.
* Tambahkan section Work Instruction di `README.rst`.

Tidak ada perubahan perilaku fungsional — hanya dokumentasi, docstring, dan penggantian mekanisme cache-refresh di unit test.

## Verifikasi

Keenam validator kepatuhan `status=OK` untuk modul ini:

```
#VALIDATOR name=module    target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_quotation_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-service modules=1 failed=0 skipped=0 status=OK`

Closes #115