### PR TITLE
[UPD] ssi_service_quotation_project - perbaiki temuan audit kepatuhan

### DIFF
--- a/ssi_service_quotation_project/README.rst
+++ b/ssi_service_quotation_project/README.rst
@@ -7,6 +7,11 @@ Service Quotation - Project Integration
 =======================================
 
 
+Work Instruction
+================
+
+* `Mark Service Quotation as Win <docs/service_quotation/07-win.html>`_
+
 Installation
 ============
 

--- a/ssi_service_quotation_project/docs/service_quotation/07-win.md
+++ b/ssi_service_quotation_project/docs/service_quotation/07-win.md
@@ -1,0 +1,14 @@
+# Mark Service Quotation as Win
+
+> **Module:** ssi_service_quotation_project\
+> **Extends:** ssi_service_quotation — model `service.quotation`, aksi `07-win`
+
+## Additional Post-Condition
+
+- The **Service Contract** automatically created by this action (see the base module's
+  Post-Condition) has its **Auto Create Project** field pre-filled from the quotation's
+  **Type**: when the **Type**'s **Auto Create Project** is checked, the new contract's
+  **Auto Create Project** is checked too. This mirrors the same default a user would get
+  by manually selecting **Type** on a new Service Contract form (see the
+  `ssi_service_project` module's onchange on **Type**), which the base contract-creation
+  flow would otherwise skip.

--- a/ssi_service_quotation_project/models/service_quotation.py
+++ b/ssi_service_quotation_project/models/service_quotation.py
@@ -6,12 +6,33 @@ from odoo import models
 
 
 class ServiceQuotation(models.Model):
+    """
+    Adds automatic project creation defaults to won quotations.
+    Ensures the ``service.contract`` generated when a quotation is
+    marked Win inherits the same ``auto_create_project`` onchange
+    default a user gets when manually picking Type on a new contract,
+    since :meth:`_create_contract` builds the contract with ``new()``
+    instead of going through the form's onchange chain.
+    """
+
     _name = "service.quotation"
     _inherit = [
         "service.quotation",
     ]
 
     def _compute_contract_onchange(self, temp_record):
+        """Extend the base onchange chain with the project default.
+
+        Runs ``onchange_auto_create_project`` (added by
+        ``ssi_service_project``) on the in-memory ``service.contract``
+        record so its ``auto_create_project`` field is pre-filled from
+        the quotation's Type before the contract is created.
+
+        :param temp_record: ``service.contract`` in-memory record
+            built with :meth:`~odoo.models.Model.new`.
+        :return: the same ``temp_record``, with ``auto_create_project``
+            filled in addition to the base onchanges.
+        """
         _super = super(ServiceQuotation, self)
         _super._compute_contract_onchange(temp_record)
         temp_record.onchange_auto_create_project()

--- a/ssi_service_quotation_project/tests/test_data_service_quotation_project.yaml
+++ b/ssi_service_quotation_project/tests/test_data_service_quotation_project.yaml
@@ -61,10 +61,14 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
+      - step: "Assert quotation confirmed (refresh cache)"
+        action: "assert"
         target: "quotation"
-        method: "invalidate_cache"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve quotation"
         action: "call"

--- a/ssi_service_quotation_project/tests/test_service_quotation_project.py
+++ b/ssi_service_quotation_project/tests/test_service_quotation_project.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSvcQuotProject(YamlTransactionCase):
+    """Cover the ``service.quotation`` create/confirm/approve flow.
+
+    Exercises the base workflow provided by ``ssi_service_quotation``
+    with this module installed, to guard against regressions in the
+    ``_compute_contract_onchange`` override it adds.
+    """
+
     def test_service_quotation_project(self):
+        """Run the create/confirm/approve YAML scenario."""
         self.run_yaml_scenario("test_data_service_quotation_project.yaml")


### PR DESCRIPTION
## Ringkasan

Memperbaiki 8 butir temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-service` pada modul `ssi_service_quotation_project`:

* `modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali` — ditulis IK extension `docs/service_quotation/07-win.md` (arketipe Additional Post-Condition, mendokumentasikan efek Auto Create Project pada contract hasil Win), beserta entri Work Instruction di README.rst.
* `setiap-class-method-punya-docstring` — docstring ditambahkan untuk class `ServiceQuotation` dan method `_compute_contract_onchange`.
* `setiap-class-method-test-punya-docstring` — docstring ditambahkan untuk class test, dan method `test_service_quotation_project`.
* `tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh` — step `invalidate_cache` manual dihapus dari skenario YAML, diganti step `assert` dengan `refresh: true`.

Tidak ada perubahan perilaku fungsional, penambahan field/fitur baru, atau penggantian nama class/method/field/model.

## Validasi

Keenam validator kepatuhan lolos `status=OK` untuk modul ini:

```
#VALIDATOR name=module    target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_service_quotation_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`pre-commit-gate.sh` mencetak `GATE OK: 6 pemeriksaan, 0 pelanggaran baru.`

## Test plan

- [x] CI GitHub menjalankan unit test yang sudah ada (skenario YAML tetap lolos apa adanya, hanya `invalidate_cache` diganti `refresh: true`)
- [x] `verify-module.sh`, `validate-ik.sh`, `validate-unit-test.sh`, `validate-tour.sh`, `validate-po.sh`, `validate-web.sh` semuanya `status=OK`

Closes #116