### PR TITLE
[UPD] ssi_service_operating_unit - perbaiki blok metadata IK delta

### DIFF
--- a/ssi_service_operating_unit/docs/service_contract/01-create.md
+++ b/ssi_service_operating_unit/docs/service_contract/01-create.md
@@ -1,7 +1,7 @@
 # Create Service Contract
 
-> **Module:** ssi_service_operating_unit **Extends:** ssi_service — model
-> `service.contract`, aksi `01-create`
+> **Module:** ssi_service_operating_unit\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`
 
 ## Additional Fields
 


### PR DESCRIPTION
## Ringkasan

* Pecah baris blockquote `Module:`/`Extends:` pada `docs/service_contract/01-create.md`
  menjadi dua baris terpisah dengan hard line break (`\`), mengikuti bentuk baku IK
  delta modul extension (`modul-extension.md` §Struktur file IK delta).
* Parser metadata `validate-ik.sh` ter-anchor pada satu kunci per baris blockquote,
  sehingga `Extends:` pada baris gabungan sebelumnya tidak terbaca dan berkas salah
  dikenali sebagai IK penuh (bukan IK delta), menuntut section Flow/Pre/Post-Condition
  yang memang sengaja tidak diduplikasi IK delta.
* Isi section `## Additional Fields` dan `## Modified — Record Visibility` tidak diubah.

## Hasil validator

```
#VALIDATOR name=ik target=/home/andhit-r/odoo-code/opnsynid-service/ssi_service_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

## Test plan

- [x] `validate-ik.sh <path-modul> 14.0` keluar `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] Gerbang validator (`pre-commit-gate.sh`) keluar `GATE OK`
- [ ] CI GitHub hijau

Closes #151