### PR TITLE
[UPD] ssi_service_project - perbaiki blok metadata IK delta

### DIFF
--- a/ssi_service_project/docs/service_contract/01-create.md
+++ b/ssi_service_project/docs/service_contract/01-create.md
@@ -1,7 +1,7 @@
 # Create Service Contract
 
-> **Module:** ssi_service_project **Extends:** ssi_service — model `service.contract`,
-> aksi `01-create`
+> **Module:** ssi_service_project\
+> **Extends:** ssi_service — model `service.contract`, aksi `01-create`
 
 ## Additional Fields
 

--- a/ssi_service_project/docs/service_contract/05-approve.md
+++ b/ssi_service_project/docs/service_contract/05-approve.md
@@ -1,7 +1,7 @@
 # Approve Service Contract
 
-> **Module:** ssi_service_project **Extends:** ssi_service — model `service.contract`,
-> aksi `05-approve`
+> **Module:** ssi_service_project\
+> **Extends:** ssi_service — model `service.contract`, aksi `05-approve`
 
 ## Additional Post-Condition
 


### PR DESCRIPTION
## Ringkasan

Memperbaiki blok metadata IK delta di dua berkas `ssi_service_project` yang gagal
divalidasi `validate-ik.sh` karena baris `Module:`/`Extends:` ditulis dalam satu paragraf
blockquote (soft-wrap), bukan dua baris terpisah dengan hard break. Akibatnya
`Extends:` tak terbaca, berkas dinilai `IS_DELTA=0`, dan dituntut section penuh
(Model/Menu/Actor + Pre-Condition/Flow/Post-Condition) yang justru sengaja tidak
diduplikasi oleh IK delta.

* `docs/service_contract/01-create.md`
* `docs/service_contract/05-approve.md`

Peringatan tour (`tak-ada-tour-yang-menyebut-ik-...-05-approve`) ikut hilang sebagai efek
samping perbaikan metadata — tidak ada tour baru yang ditulis.

## Hasil validator

```
#VALIDATOR name=ik target=/home/andhit-r/odoo-code/opnsynid-service/ssi_service_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`LOLOS: 0 ERROR, 0 peringatan, 0 tertunda.`

Closes #152